### PR TITLE
add release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: release
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - "*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "14.x" # You might need to adjust this value to your own version
+      - run: npm install
+      - run: npm run build
+      - name: publish artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: build
+      - name: create release
+        uses: softprops/action-gh-release@v1
+        with:
+          prerelease: true
+          draft: false
+          generate_release_notes: true
+          files: build/*
+


### PR DESCRIPTION
this release script will create new releases when we push a tag matching `*.*.*` eg `0.2.3`. When we release a major or minor version bump, we'll still need to tag with the full three numbers. So version 1 will be `1.0.0`