### PR TITLE
#16/fix context menu

### DIFF
--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -220,7 +220,6 @@ export class ObloggerView extends ItemView {
                     if(!this.app.workspace.getActiveViewOfType(ObloggerView)?.getState()) {
                         return;
                     }
-                    console.debug(`Hiding rename for file ${file.name}...`)
                     // These types are added at run-time on top of Menu? Or Menu is
                     // the wrong type to be using and these are already defined
                     // somewhere.
@@ -232,9 +231,6 @@ export class ObloggerView extends ItemView {
                     }
                     const fileMenu = menu as FileMenu;
                     const renameAction = fileMenu.items.find(i => i?.titleEl?.innerHTML === "Rename");
-                    if (!renameAction) {
-                        console.log("Rename not found!");
-                    }
                     renameAction && fileMenu.items.remove(renameAction);
                 })
             );

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -210,6 +210,34 @@ export class ObloggerView extends ItemView {
             this.setFocusedItem = fileExplorer.setFocusedItem;
             this.afterCreate = fileExplorer.afterCreate;
             this.isItem = (file: TFile) => false;
+
+            this.registerEvent(
+                // todo(#172): right now, we're disabling rename because it's broken
+                //  however, we should fix it with either custom rename or by getting
+                //  the in-line rename to work right
+                this.app.workspace.on("file-menu", (menu, file) => {
+                    // Don't hide it for other views (like file-explorer)
+                    if(!this.app.workspace.getActiveViewOfType(ObloggerView)?.getState()) {
+                        return;
+                    }
+                    console.debug(`Hiding rename for file ${file.name}...`)
+                    // These types are added at run-time on top of Menu? Or Menu is
+                    // the wrong type to be using and these are already defined
+                    // somewhere.
+                    class FileMenuAction {
+                        titleEl: HTMLElement;
+                    }
+                    class FileMenu extends Menu {
+                        items: FileMenuAction[]
+                    }
+                    const fileMenu = menu as FileMenu;
+                    const renameAction = fileMenu.items.find(i => i?.titleEl?.innerHTML === "Rename");
+                    if (!renameAction) {
+                        console.log("Rename not found!");
+                    }
+                    renameAction && fileMenu.items.remove(renameAction);
+                })
+            );
         });
     }
 
@@ -698,33 +726,6 @@ export class ObloggerView extends ItemView {
     }
 
     async onOpen() {
-        this.registerEvent(
-            // todo(#172): right now, we're disabling rename because it's broken
-            //  however, we should fix it with either custom rename or by getting
-            //  the in-line rename to work right
-            this.app.workspace.on("file-menu", (menu, file) => {
-                // Don't hide it for other views (like file-explorer)
-                if(!this.app.workspace.getActiveViewOfType(ObloggerView)?.getState()) {
-                    return;
-                }
-                console.debug(`Hiding rename for file ${file.name}...`)
-                // These types are added at run-time on top of Menu? Or Menu is
-                // the wrong type to be using and these are already defined
-                // somewhere.
-                class FileMenuAction {
-                    titleEl: HTMLElement;
-                }
-                class FileMenu extends Menu {
-                    items: FileMenuAction[]
-                }
-                if (menu instanceof FileMenu) {
-                    const renameAction = menu.items.find(i => i?.titleEl?.innerHTML === "Rename");
-                    renameAction && menu.items.remove(renameAction);
-                }
-                return;
-            })
-        );
-
         this.containerEl.empty();
 
         const header = document.createElement("div");

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -36,6 +36,7 @@ class FileItem {
     el: HTMLElement;
     titleInnerEl: HTMLElement;
     file: TFile;
+    selfEl: HTMLElement;
 
     constructor(
         file: TFile,
@@ -47,6 +48,9 @@ class FileItem {
         this.file = file;
         this.titleEl = titleEl;
         this.titleInnerEl = titleInnerEl;
+
+        // not sure if this is the right thing to set it to
+        this.selfEl = el;
     }
 }
 
@@ -102,6 +106,7 @@ export class ObloggerView extends ItemView {
     openFileContextMenu: (e: MouseEvent, container: HTMLDivElement) => void;
     setFocusedItem: (fileItem: FileItem) => void;
     afterCreate: (file: TFile, unknownBool: boolean) => void;
+    isItem: (file: TFile) => boolean;
 
     constructor(
         leaf: WorkspaceLeaf,
@@ -204,6 +209,7 @@ export class ObloggerView extends ItemView {
             this.openFileContextMenu = fileExplorer.openFileContextMenu;
             this.setFocusedItem = fileExplorer.setFocusedItem;
             this.afterCreate = fileExplorer.afterCreate;
+            this.isItem = (file: TFile) => false;
         });
     }
 


### PR DESCRIPTION
fixes #16 

![image](https://github.com/loftTech/obsidian-oblogger/assets/1900880/c566cd9d-e696-4093-9b33-0195217b0d4b)

- adds some missing members that file explorer accesses when the context menu is selected (clears console errors)
- sets up the context menu overrides (removing rename) only after the file-explorer plugin is loaded
- cleans up debug statements