### PR TITLE
sorting in tag groups

### DIFF
--- a/src/dailies_container.ts
+++ b/src/dailies_container.ts
@@ -51,6 +51,10 @@ export class DailiesContainer extends ViewContainer {
         return "Daily Notes";
     }
 
+    protected getTitleTooltip(): string {
+        return "";
+    }
+
     protected getTitleIcon(): string {
         return "";
     }

--- a/src/files_container.ts
+++ b/src/files_container.ts
@@ -52,6 +52,10 @@ export class FilesContainer extends ViewContainer {
         return "Files";
     }
 
+    protected getTitleTooltip(): string {
+        return "";
+    }
+
     protected getTitleIcon(): string {
         return "";
     }

--- a/src/files_container.ts
+++ b/src/files_container.ts
@@ -244,33 +244,24 @@ export class FilesContainer extends ViewContainer {
             return file.extension !== "md";
         });
 
+        const ascending = this.getGroupSetting()?.sortAscending ?? true;
+
         switch (this.getGroupSetting()?.sortMethod ?? ContainerSortMethod.TYPE) {
             case ContainerSortMethod.ALPHABETICAL:
-                this.buildAlphabeticalFileStructure(
-                    includedFiles,
-                    this.getGroupSetting()?.sortAscending ?? true);
+                this.buildAlphabeticalFileStructure(includedFiles, ascending);
                 break;
             case ContainerSortMethod.CTIME:
-                this.buildDateFileStructure(
-                    includedFiles,
-                    this.getGroupSetting()?.sortAscending ?? true,
-                    true);
+                this.buildDateFileStructure(includedFiles, ascending, true);
                 break;
             case ContainerSortMethod.MTIME:
-                this.buildDateFileStructure(
-                    includedFiles,
-                    this.getGroupSetting()?.sortAscending ?? true,
-                    false);
+                this.buildDateFileStructure(includedFiles, ascending, false);
                 break;
             case ContainerSortMethod.EXTENSION:
-                this.buildExtensionFileStructure(
-                    includedFiles,
-                    this.getGroupSetting()?.sortAscending ?? true);
+                this.buildExtensionFileStructure(includedFiles, ascending);
                 break;
             case ContainerSortMethod.TYPE:
-                this.buildTypeFileStructure(
-                    includedFiles,
-                    this.getGroupSetting()?.sortAscending ?? true);
+            default:
+                this.buildTypeFileStructure(includedFiles, ascending);
                 break;
         }
     }

--- a/src/files_container.ts
+++ b/src/files_container.ts
@@ -244,7 +244,7 @@ export class FilesContainer extends ViewContainer {
             return file.extension !== "md";
         });
 
-        switch (this.getGroupSetting()?.sortMethod) {
+        switch (this.getGroupSetting()?.sortMethod ?? ContainerSortMethod.TYPE) {
             case ContainerSortMethod.ALPHABETICAL:
                 this.buildAlphabeticalFileStructure(
                     includedFiles,

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -8,7 +8,7 @@ import {
     View,
     Notice
 } from "obsidian";
-import { ObloggerSettings, RxGroupType, TagGroup as SettingsTagGroup } from "./settings";
+import { ObloggerSettings, RxGroupType, OtcGroupSettings as SettingsTagGroup } from "./settings";
 import { TagGroupContainer } from "./tag_group_container";
 import { DailiesContainer } from "./dailies_container";
 import { GroupFolder } from "./group_folder";

--- a/src/recents_container.ts
+++ b/src/recents_container.ts
@@ -56,6 +56,10 @@ export class RecentsContainer extends ViewContainer {
         return "Recents";
     }
 
+    protected getTitleTooltip(): string {
+        return "";
+    }
+
     protected getTitleIcon(): string {
         return "";
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -40,7 +40,7 @@ export const RxGroupType = {
     DAILIES: "dailies"
 }
 
-// todo: combine this with OtcGroupSettings
+// TODO(#64): combine this with OtcGroupSettings
 export interface RxGroupSettings {
     groupName: string;
     collapsedFolders: string[];

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -41,11 +41,11 @@ export const RxGroupType = {
 }
 
 interface RxGroupSettings {
-    groupName: string,
-    collapsedFolders: string[],
-    isVisible: boolean,
-    sortMethod: string,
-    sortAscending: boolean
+    groupName: string;
+    collapsedFolders: string[];
+    isVisible: boolean;
+    sortMethod: string;
+    sortAscending: boolean;
 }
 
 export const PostLogAction = {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,6 @@
 import { TFile } from "obsidian";
 
-export interface TagGroup {
+export interface OtcGroupSettings {
     tag: string;
     collapsedFolders: string[];
     isPinned: boolean;
@@ -55,7 +55,7 @@ export const PostLogAction = {
 export interface ObloggerSettings {
     loggingPath: string;
     avatarPath: string;
-    tagGroups: TagGroup[];
+    tagGroups: OtcGroupSettings[];
     excludedFolders: string[];
     recentsCount: number;
     avatarVisible: boolean;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,6 +4,8 @@ export interface OtcGroupSettings {
     tag: string;
     collapsedFolders: string[];
     isPinned: boolean;
+    sortMethod?: string;
+    sortAscending?: boolean;
 }
 
 export const ContainerSortMethod = {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -40,7 +40,8 @@ export const RxGroupType = {
     DAILIES: "dailies"
 }
 
-interface RxGroupSettings {
+// todo: combine this with OtcGroupSettings
+export interface RxGroupSettings {
     groupName: string;
     collapsedFolders: string[];
     isVisible: boolean;

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -147,6 +147,7 @@ export class TagGroupContainer extends ViewContainer {
 
             [
                 ContainerSortMethod.ALPHABETICAL,
+                ContainerSortMethod.CTIME,
                 ContainerSortMethod.MTIME
             ].forEach(method => {
                 menu.addItem(item => {
@@ -211,6 +212,10 @@ export class TagGroupContainer extends ViewContainer {
             case ContainerSortMethod.MTIME:
                 return (fileA: TFile, fileB: TFile) => {
                     return fileA.stat.mtime - fileB.stat.mtime;
+                }
+            case ContainerSortMethod.CTIME:
+                return (fileA: TFile, fileB: TFile) => {
+                    return fileA.stat.ctime - fileB.stat.ctime;
                 }
             case ContainerSortMethod.ALPHABETICAL:
             default:

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -91,13 +91,17 @@ export class TagGroupContainer extends ViewContainer {
     }
 
     protected getPillTooltipText(): string {
+        return "";
+    }
+
+    protected getTitleTooltip(): string {
         if (this.getIsolatedTagMatch()) {
             return "Associated tags:\n\n" + Object.keys(this.getAllAssociatedTags([]))
                 .sort()
                 .map(tag => `#${tag}`)
                 .join("\n");
         }
-        return this.groupName.contains("/") ? this.groupName : "";
+        return `#${this.groupName}`;
     }
 
     protected getPillIcon(): string {
@@ -225,6 +229,8 @@ export class TagGroupContainer extends ViewContainer {
         const ascending = this.getGroupSetting()?.sortAscending ?? true;
         const fileSortingFn = this.getFileSortingFn();
 
+        // todo: don't always sort tags. only sort them if sorting is alphabetical,
+        //  otherwise default to alpha ascending
         Object.keys(tagFiles).sort((tagA: string, tagB: string) => {
             return (ascending ? 1 : -1) * (tagA < tagB ? -1 : tagA > tagB ? 1 : 0);
         }).forEach((tag: string) => {

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -1,7 +1,7 @@
 import { App, getAllTags, TFile } from "obsidian";
 import { FileClickCallback, FileAddedCallback } from "./group_folder";
 import { ViewContainer } from "./view_container";
-import { ObloggerSettings } from "./settings";
+import { ContainerSortMethod, ObloggerSettings } from "./settings";
 
 
 type TagFileMap = { [key: string]: TFile[] };
@@ -155,13 +155,14 @@ export class TagGroupContainer extends ViewContainer {
             }, {});
     }
 
-    protected buildFileStructure(excludedFolders: string[]) {
-        const tags = this.getAllAssociatedTags(excludedFolders);
-        const isolatedGroupName = this.getIsolatedTagMatch()?.at(1);
-
-        Object.keys(tags).sort().forEach((tag: string) => {
+    protected buildAlphabeticalFileStructure(
+        tagFiles: TagFileMap,
+        ascending: boolean,
+        isolatedGroupName?: string
+    ) {
+        Object.keys(tagFiles).sort().forEach((tag: string) => {
             const subTag = tag.replace(this.groupName, "");
-            tags[tag]
+            tagFiles[tag]
                 .sort((fileA: TFile, fileB: TFile) => {
                     const bookmarkSorting = this.sortFilesByBookmark(fileA, fileB);
                     if (bookmarkSorting != 0) {
@@ -185,6 +186,29 @@ export class TagGroupContainer extends ViewContainer {
                     );
                 });
         });
+    }
+
+    protected buildDateFileStructure(
+        tagFiles: TagFileMap,
+        ascending: boolean,
+        isolatedGroupName?: string
+    ) {
+    }
+
+    protected buildFileStructure(excludedFolders: string[]) {
+        const tagFiles = this.getAllAssociatedTags(excludedFolders);
+        const isolatedGroupName = this.getIsolatedTagMatch()?.at(1);
+        const ascending = this.getGroupSetting()?.sortAscending ?? true;
+
+        switch (this.getGroupSetting()?.sortMethod ?? ContainerSortMethod.ALPHABETICAL) {
+            case ContainerSortMethod.MTIME:
+                this.buildDateFileStructure(tagFiles, ascending, isolatedGroupName);
+                break;
+            case ContainerSortMethod.ALPHABETICAL:
+            default:
+                this.buildAlphabeticalFileStructure(tagFiles, ascending, isolatedGroupName);
+                break;
+        }
     }
 
     protected getContainerClass(): string {

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -82,16 +82,11 @@ export class TagGroupContainer extends ViewContainer {
     }
 
     protected getPillText(): string {
-        if (this.getIsolatedTagMatch()) {
-            return "• • •";
-        }
-        return "#" + (this.groupName.split("/").first() ?? "") + (
-            this.groupName.contains("/") ? "..." : ""
-        )
+        return getSortMethodDisplayText(this.getGroupSetting()?.sortMethod ?? ContainerSortMethod.ALPHABETICAL);
     }
 
     protected getPillTooltipText(): string {
-        return "";
+        return "Sort";
     }
 
     protected getTitleTooltip(): string {
@@ -105,7 +100,9 @@ export class TagGroupContainer extends ViewContainer {
     }
 
     protected getPillIcon(): string {
-        return "";
+        return (this.getGroupSetting()?.sortAscending ?? true) ?
+            "down-arrow-with-tail" :
+            "up-arrow-with-tail"
     }
 
     protected getPillClickHandler(): ((e: MouseEvent) => void) | undefined {

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -160,7 +160,9 @@ export class TagGroupContainer extends ViewContainer {
         ascending: boolean,
         isolatedGroupName?: string
     ) {
-        Object.keys(tagFiles).sort().forEach((tag: string) => {
+        Object.keys(tagFiles).sort((tagA: string, tagB: string) => {
+            return (ascending ? 1 : -1) * (tagA < tagB ? -1 : tagA > tagB ? 1 : 0);
+        }).forEach((tag: string) => {
             const subTag = tag.replace(this.groupName, "");
             tagFiles[tag]
                 .sort((fileA: TFile, fileB: TFile) => {
@@ -168,7 +170,7 @@ export class TagGroupContainer extends ViewContainer {
                     if (bookmarkSorting != 0) {
                         return bookmarkSorting;
                     }
-                    return fileA.name < fileB.name ? -1 : fileA.name > fileB.name ? 1 : 0;
+                    return (ascending ? 1 : -1) * (fileA.name < fileB.name ? -1 : fileA.name > fileB.name ? 1 : 0);
                 })
                 .forEach((file: TFile) => {
                     let remainingTag = subTag.startsWith("/") ? subTag.slice(1) : subTag;

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -207,8 +207,8 @@ export class TagGroupContainer extends ViewContainer {
             }, {});
     }
 
-    private getFileSortingFn() {
-        switch (this.getGroupSetting()?.sortMethod ?? ContainerSortMethod.ALPHABETICAL) {
+    private getFileSortingFn(sortMethod: string) {
+        switch (sortMethod) {
             case ContainerSortMethod.MTIME:
                 return (fileA: TFile, fileB: TFile) => {
                     return fileA.stat.mtime - fileB.stat.mtime;
@@ -229,12 +229,14 @@ export class TagGroupContainer extends ViewContainer {
         const tagFiles = this.getAllAssociatedTags(excludedFolders);
         const isolatedGroupName = this.getIsolatedTagMatch()?.at(1);
         const ascending = this.getGroupSetting()?.sortAscending ?? true;
-        const fileSortingFn = this.getFileSortingFn();
+        const sortMethod = this.getGroupSetting()?.sortMethod ?? ContainerSortMethod.ALPHABETICAL;
+        const fileSortingFn = this.getFileSortingFn(sortMethod);
 
-        // todo: don't always sort tags. only sort them if sorting is alphabetical,
-        //  otherwise default to alpha ascending
         Object.keys(tagFiles).sort((tagA: string, tagB: string) => {
-            return (ascending ? 1 : -1) * (tagA < tagB ? -1 : tagA > tagB ? 1 : 0);
+            // don't always sort tags. only sort them if sorting is alphabetical,
+            // otherwise default to alpha ascending
+            const modifier = sortMethod === ContainerSortMethod.ALPHABETICAL ? (ascending ? 1 : -1) : 1;
+            return modifier * (tagA < tagB ? -1 : tagA > tagB ? 1 : 0);
         }).forEach((tag: string) => {
             const subTag = tag.replace(this.groupName, "");
             tagFiles[tag]

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -110,8 +110,8 @@ export class TagGroupContainer extends ViewContainer {
 
     private getAllAssociatedTags(excludedFolders: string[]): TagFileMap {
         interface Item {
-            file: TFile,
-            tags: string[]
+            file: TFile;
+            tags: string[];
         }
 
         const isolatedGroupName = this.getIsolatedTagMatch()?.at(1);

--- a/src/untagged_container.ts
+++ b/src/untagged_container.ts
@@ -50,6 +50,10 @@ export class UntaggedContainer extends ViewContainer {
         return "Untagged";
     }
 
+    protected getTitleTooltip(): string {
+        return "";
+    }
+
     protected getTitleIcon(): string {
         return "";
     }

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -77,13 +77,10 @@ export abstract class ViewContainer extends GroupFolder {
     }
 
     protected getGroupSetting() {
-        console.log(`looking for ${this.groupName} in rx groups: ${this.settings.rxGroups.map(g => g.groupName)} and otc groups: ${this.settings.tagGroups.map(g => g.tag)}`)
-        const settings = (
+        return (
             (this.settings.rxGroups.find(group => group.groupName === this.groupName)) ??
             (this.settings.tagGroups.find(group => group.tag === this.groupName))
         );
-        console.log(`settings found: ${settings}`)
-        return settings;
     }
 
     protected requestRender() {

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -1,6 +1,6 @@
 import { App, Menu, setIcon, TFile } from "obsidian";
 import { FileClickCallback, GroupFolder, FileAddedCallback } from "./group_folder";
-import { ObloggerSettings } from "./settings";
+import { ObloggerSettings, RxGroupSettings } from "./settings";
 
 export abstract class ViewContainer extends GroupFolder {
     settings: ObloggerSettings;
@@ -73,11 +73,17 @@ export abstract class ViewContainer extends GroupFolder {
     }
 
     protected isVisible(): boolean {
-        return this.getGroupSetting()?.isVisible ?? true;
+        return (this.getGroupSetting() as RxGroupSettings)?.isVisible ?? true;
     }
 
     protected getGroupSetting() {
-        return this.settings.rxGroups.find(group => group.groupName === this.groupName);
+        console.log(`looking for ${this.groupName} in rx groups: ${this.settings.rxGroups.map(g => g.groupName)} and otc groups: ${this.settings.tagGroups.map(g => g.tag)}`)
+        const settings = (
+            (this.settings.rxGroups.find(group => group.groupName === this.groupName)) ??
+            (this.settings.tagGroups.find(group => group.tag === this.groupName))
+        );
+        console.log(`settings found: ${settings}`)
+        return settings;
     }
 
     protected requestRender() {

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -17,6 +17,7 @@ export abstract class ViewContainer extends GroupFolder {
     pinCallback: ((pin: boolean) => void) | undefined;
 
     protected abstract getTitleText(): string;
+    protected abstract getTitleTooltip(): string;
     protected abstract getTitleIcon(): string;
     protected abstract getTitleIconTooltip(): string;
     protected abstract getPillText(): string;
@@ -212,6 +213,7 @@ export abstract class ViewContainer extends GroupFolder {
             const contextMenu = this.getContextMenu();
             contextMenu && contextMenu.showAtMouseEvent(e);
         });
+        titleText.ariaLabel = this.getTitleTooltip();
 
         return titleTextContainer;
     }


### PR DESCRIPTION
fixes #59

- adds sorting method and orientation to tag groups
- adds function to view containers for adding a title tool tip
- moves tag group pill tooltip to the title as a tooltip
- renames `TagGroup` in settings to `OtcGroupSettings` to more align with the better named `RxGroupSettings`
- uses more consistent line termination in `interfaces` (using `;` instead of sometimes using `,`)
- changes `getGroupSettings()` to return both `OtcGroupSettings` and `RxGroupSettings` instead of just `RxGroupSettings`