### PR TITLE
#76: improve performance issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "scripts": {
         "dev": "npx rollup --config rollup-debug.config.js -w",
         "build": "npx rollup --config rollup.config.js --environment BUILD:production",
-        "version": "node scripts/version-bump.mjs && git add manifest.json versions.json"
+        "version": "node scripts/version-bump.mjs && git add manifest.json versions.json",
+        "lint": "npx eslint src/*.ts"
     },
     "keywords": [
         "obsidian",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import { CachedMetadata, TFile } from "obsidian";
+
 const MINIMUM_DESKTOP_RESOLUTION_WIDTH_PX = 500;
 
 // Using a minimum resolution width to determine desktop (including ipad)
@@ -5,4 +7,9 @@ const MINIMUM_DESKTOP_RESOLUTION_WIDTH_PX = 500;
 // position.
 export function isDesktopLikeResolution() {
     return window.screen.availWidth >= MINIMUM_DESKTOP_RESOLUTION_WIDTH_PX;
+}
+
+export interface FileModificationEventDetails {
+    file: TFile;
+    metadata: CachedMetadata;
 }

--- a/src/dailies_container.ts
+++ b/src/dailies_container.ts
@@ -40,10 +40,10 @@ export class DailiesContainer extends ViewContainer {
         this.fileEntryDates = [];
     }
 
-    protected shouldRerenderOnModification(modifiedFile: FileModificationEventDetails): boolean {
-        // todo: get this from somewhere else
-        const excludedFolders: string[] = [];
-
+    protected shouldRerenderOnModification(
+        modifiedFile: FileModificationEventDetails,
+        excludedFolders: string[]
+    ): boolean {
         const shouldBeIncluded = this.shouldIncludeFile(modifiedFile.file, excludedFolders);
         const isIncluded = this.hasFileWithin(modifiedFile.file);
 

--- a/src/dailies_container.ts
+++ b/src/dailies_container.ts
@@ -142,10 +142,8 @@ export class DailiesContainer extends ViewContainer {
             return false;
         }
 
-        if (!getAllTags(cache)?.contains("#" + this.settings.dailiesTag)) {
-            return false;
-        }
-        return true;
+        return getAllTags(cache)?.contains("#" + this.settings.dailiesTag) ?? false;
+
     }
 
     private getDailyDate(daily: TFile, dayPrecision: boolean): string {

--- a/src/dailies_container.ts
+++ b/src/dailies_container.ts
@@ -3,8 +3,11 @@ import { FileClickCallback, FileAddedCallback } from "./group_folder";
 import { ViewContainer } from "./view_container";
 import { ObloggerSettings, RxGroupType } from "./settings";
 import { NewTagModal } from "./new_tag_modal";
+import { FileModificationEventDetails } from "./constants";
 
 export class DailiesContainer extends ViewContainer {
+    fileEntryDates: { file: TFile, date: string }[]
+
     constructor(
         app: App,
         fileClickCallback: FileClickCallback,
@@ -33,6 +36,32 @@ export class DailiesContainer extends ViewContainer {
             false, // canBePinned
             undefined,
             false); // isPinned
+
+        this.fileEntryDates = [];
+    }
+
+    protected shouldRerenderOnModification(modifiedFile: FileModificationEventDetails): boolean {
+        // todo: get this from somewhere else
+        const excludedFolders: string[] = [];
+
+        const shouldBeIncluded = this.shouldIncludeFile(modifiedFile.file, excludedFolders);
+        const isIncluded = this.hasFileWithin(modifiedFile.file);
+
+        if (shouldBeIncluded != isIncluded) {
+            return true;
+        }
+
+        if (!isIncluded && !shouldBeIncluded) {
+            // file is irrelevant
+            return false;
+        }
+
+        // file is already included and should be, but check if the date changed
+        const existingDate = this.fileEntryDates.find(
+            fileDate => fileDate.file === modifiedFile.file)?.date;
+        const modifiedDate = this.getDailyDate(modifiedFile.file, true);
+
+        return existingDate != modifiedDate;
     }
 
     protected getEmptyMessage(): string {
@@ -102,19 +131,40 @@ export class DailiesContainer extends ViewContainer {
         return "rx-child";
     }
 
-    protected buildFileStructure(excludedFolders: string[]) {
-        const getDailyDate = (daily: TFile, dayPrecision: boolean): string => {
-            const cache = this.app.metadataCache.getFileCache(daily);
-            return moment(cache?.frontmatter?.day ??
-                cache?.frontmatter?.created ??
-                daily.stat.ctime).format(dayPrecision ? "YYYY-MM-DD" : "YYYY-MM");
+    private shouldIncludeFile(file: TFile, excludedFolders: string[]): boolean {
+        if (file.parent && excludedFolders.contains(file.parent.path)) {
+            return false;
         }
+
+        const cache = this.app.metadataCache.getFileCache(file);
+        if (cache === null) {
+            return false;
+        }
+
+        if (!getAllTags(cache)?.contains("#" + this.settings.dailiesTag)) {
+            return false;
+        }
+        return true;
+    }
+
+    private getDailyDate(daily: TFile, dayPrecision: boolean): string {
+        const cache = this.app.metadataCache.getFileCache(daily);
+        return moment(cache?.frontmatter?.day ??
+            cache?.frontmatter?.created ??
+            daily.stat.ctime).format(dayPrecision ? "YYYY-MM-DD" : "YYYY-MM");
+    }
+
+    protected buildFileStructure(excludedFolders: string[]) {
+        this.fileEntryDates = [];
 
         this.app.vault
             .getFiles()
+            .filter((file: TFile) => {
+                return this.shouldIncludeFile(file, excludedFolders);
+            })
             .sort((fileA: TFile, fileB: TFile): number => {
-                const monthA = getDailyDate(fileA, false);
-                const monthB = getDailyDate(fileB, false);
+                const monthA = this.getDailyDate(fileA, false);
+                const monthB = this.getDailyDate(fileB, false);
                 if (monthA > monthB) {
                     return -1;
                 }
@@ -127,25 +177,13 @@ export class DailiesContainer extends ViewContainer {
                     return bookmarkSorting;
                 }
 
-                const dayA = getDailyDate(fileA, true);
-                const dayB = getDailyDate(fileB, true);
+                const dayA = this.getDailyDate(fileA, true);
+                const dayB = this.getDailyDate(fileB, true);
                 return dayA > dayB ? -1 : dayA < dayB ? 1 : 0;
             })
             .forEach((file: TFile) => {
-                if (file.parent && excludedFolders.contains(file.parent.path)) {
-                    return;
-                }
-
-                const cache = this.app.metadataCache.getFileCache(file);
-                if (cache === null) {
-                    return;
-                }
-
-                if (!getAllTags(cache)?.contains("#" + this.settings.dailiesTag)) {
-                    return;
-                }
-
-                const dailyDateString = getDailyDate(file, true);
+                const dailyDateString = this.getDailyDate(file, true);
+                this.fileEntryDates.push({file, date: dailyDateString});
                 const dailyDate = moment(dailyDateString);
                 const dailyDateYear = dailyDate.format("YYYY");
                 const dailyDateMonth = dailyDate.format("MM");

--- a/src/files_container.ts
+++ b/src/files_container.ts
@@ -98,7 +98,7 @@ export class FilesContainer extends ViewContainer {
 
             const setupItem = (item: MenuItem, method: string) => {
                 item.onClick(() => {
-                    changeSortMethod(method);
+                    return changeSortMethod(method);
                 });
                 if (method === this.getGroupSetting()?.sortMethod) {
 

--- a/src/files_container.ts
+++ b/src/files_container.ts
@@ -2,7 +2,6 @@ import { ViewContainer } from "./view_container";
 import { FileAddedCallback, FileClickCallback } from "./group_folder";
 import { ObloggerSettings, ContainerSortMethod, getSortMethodDisplayText, RxGroupType, getFileType } from "./settings";
 import { App, Menu, MenuItem, moment, TFile } from "obsidian";
-import { FileModificationEventDetails } from "./constants";
 
 export class FilesContainer extends ViewContainer {
     constructor(
@@ -35,9 +34,11 @@ export class FilesContainer extends ViewContainer {
             false); // isPinned
     }
 
-    protected shouldRerenderOnModification(modifiedFile: FileModificationEventDetails): boolean {
-        // todo: enhance
-        return true;
+    protected shouldRerenderOnModification(): boolean {
+        // Since these files don't have metadata, then we never need to re-render
+        // based on a specific file change. We will re-render when more broad
+        // render events happen (like files added/deleted)
+        return false;
     }
 
     protected getEmptyMessage(): string {

--- a/src/files_container.ts
+++ b/src/files_container.ts
@@ -2,6 +2,7 @@ import { ViewContainer } from "./view_container";
 import { FileAddedCallback, FileClickCallback } from "./group_folder";
 import { ObloggerSettings, ContainerSortMethod, getSortMethodDisplayText, RxGroupType, getFileType } from "./settings";
 import { App, Menu, MenuItem, moment, TFile } from "obsidian";
+import { FileModificationEventDetails } from "./constants";
 
 export class FilesContainer extends ViewContainer {
     constructor(
@@ -32,6 +33,11 @@ export class FilesContainer extends ViewContainer {
             false, // canBePinned
             undefined,
             false); // isPinned
+    }
+
+    protected shouldRerenderOnModification(modifiedFile: FileModificationEventDetails): boolean {
+        // todo: enhance
+        return true;
     }
 
     protected getEmptyMessage(): string {

--- a/src/group_folder.ts
+++ b/src/group_folder.ts
@@ -55,6 +55,10 @@ export class GroupFolder {
         this.rootElement.addClass("folder-holder")
     }
 
+    protected hasFileWithin(file: TFile): boolean {
+        return this.sortedFiles.contains(file) || this.sortedSubFolders.some(subFolder => subFolder.hasFileWithin(file));
+    }
+
     public getCollapsedFolders(): string[] {
         return (this.isCollapsed() ? [this.folderPath] : [])
             .concat(this.sortedSubFolders.flatMap(f => f.getCollapsedFolders()));

--- a/src/group_folder.ts
+++ b/src/group_folder.ts
@@ -1,4 +1,10 @@
-import { App, ExtraButtonComponent, getAllTags, setIcon, TFile } from "obsidian";
+import {
+    App,
+    ExtraButtonComponent,
+    getAllTags,
+    setIcon,
+    TFile
+} from "obsidian";
 import { getFileTypeIcon } from "./settings";
 
 const COLLAPSED_CLASS_IDENTIFIER = "collapsed";
@@ -9,6 +15,24 @@ export type FileAddedCallback = (
     contentItem: HTMLElement,
     titleItem: HTMLElement,
     titleContentItem: HTMLElement) => void;
+
+declare module "obsidian" {
+    interface Plugin {
+        instance: never;
+    }
+    interface App {
+        internalPlugins: {
+            plugins: { [key: string]: {
+                instance: {
+                    items: {
+                        type: string;
+                        path: string;
+                    }[]
+                }
+            } }
+        }
+    }
+}
 
 export class GroupFolder {
     app: App;
@@ -197,9 +221,7 @@ export class GroupFolder {
     }
 
     protected isBookmarked(file: TFile): boolean {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        return !!app.internalPlugins.plugins.bookmarks?.instance?.items?.find(item => {
+        return !!app.internalPlugins.plugins["bookmarks"].instance?.items?.find(item => {
             return item.type === "file" && item.path === file.path
         });
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin } from "obsidian";
+import { CachedMetadata, Plugin, TAbstractFile, TFile } from "obsidian";
 import { ObloggerView, VIEW_TYPE_OBLOGGER } from "./oblogger_view";
 import { ObloggerSettings, DEFAULT_SETTINGS } from "./settings";
 import { LoggerModal } from "./logger_modal";
@@ -44,16 +44,9 @@ export default class Oblogger extends Plugin {
         await this.loadSettings();
 
         this.registerEvent(
-            // todo: what changed?
-            this.app.metadataCache.on("changed", async () => {
-                await this.getObloggerView()?.requestRender();
-            })
-        );
-
-        this.registerEvent(
             // todo: what was created?
-            this.app.vault.on("create", async () => {
-                await this.getObloggerView()?.requestRender();
+            this.app.vault.on("create", async (itemCreated: TAbstractFile) => {
+                this.getObloggerView()?.requestRender();
             })
         );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,13 +43,6 @@ export default class Oblogger extends Plugin {
     async onload() {
         await this.loadSettings();
 
-        this.registerEvent(
-            // todo: what was deleted?
-            this.app.vault.on("delete", async () => {
-                await this.getObloggerView()?.requestRender();
-            })
-        );
-
         this.registerView(
             VIEW_TYPE_OBLOGGER,
             (leaf) => new ObloggerView(

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,30 +44,35 @@ export default class Oblogger extends Plugin {
         await this.loadSettings();
 
         this.registerEvent(
+            // todo: what changed?
             this.app.metadataCache.on("changed", async () => {
                 await this.getObloggerView()?.requestRender();
             })
         );
 
         this.registerEvent(
+            // todo: what was created?
             this.app.vault.on("create", async () => {
                 await this.getObloggerView()?.requestRender();
             })
         );
 
         this.registerEvent(
+            // todo: what was modified?
             this.app.vault.on("modify", async () => {
                 await this.getObloggerView()?.requestRender();
             })
         );
 
         this.registerEvent(
+            // todo: what was renamed?
             this.app.vault.on("rename", async () => {
                 await this.getObloggerView()?.requestRender();
             })
         );
 
         this.registerEvent(
+            // todo: what was deleted?
             this.app.vault.on("delete", async () => {
                 await this.getObloggerView()?.requestRender();
             })

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,13 +44,6 @@ export default class Oblogger extends Plugin {
         await this.loadSettings();
 
         this.registerEvent(
-            // todo: what was renamed?
-            this.app.vault.on("rename", async () => {
-                await this.getObloggerView()?.requestRender();
-            })
-        );
-
-        this.registerEvent(
             // todo: what was deleted?
             this.app.vault.on("delete", async () => {
                 await this.getObloggerView()?.requestRender();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { CachedMetadata, Plugin, TAbstractFile, TFile } from "obsidian";
+import { Plugin } from "obsidian";
 import { ObloggerView, VIEW_TYPE_OBLOGGER } from "./oblogger_view";
 import { ObloggerSettings, DEFAULT_SETTINGS } from "./settings";
 import { LoggerModal } from "./logger_modal";

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,13 +44,6 @@ export default class Oblogger extends Plugin {
         await this.loadSettings();
 
         this.registerEvent(
-            // todo: what was created?
-            this.app.vault.on("create", async (itemCreated: TAbstractFile) => {
-                this.getObloggerView()?.requestRender();
-            })
-        );
-
-        this.registerEvent(
             // todo: what was modified?
             this.app.vault.on("modify", async () => {
                 await this.getObloggerView()?.requestRender();

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ export default class Oblogger extends Plugin {
             }
         }
         if (needsSaving) {
-            this.saveSettings();
+            return this.saveSettings();
         }
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,13 +44,6 @@ export default class Oblogger extends Plugin {
         await this.loadSettings();
 
         this.registerEvent(
-            // todo: what was modified?
-            this.app.vault.on("modify", async () => {
-                await this.getObloggerView()?.requestRender();
-            })
-        );
-
-        this.registerEvent(
             // todo: what was renamed?
             this.app.vault.on("rename", async () => {
                 await this.getObloggerView()?.requestRender();

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -6,7 +6,7 @@ import {
     moment,
     Menu,
     View,
-    Notice, CachedMetadata
+    Notice, CachedMetadata, TAbstractFile
 } from "obsidian";
 import { ObloggerSettings, RxGroupType, OtcGroupSettings as SettingsTagGroup } from "./settings";
 import { TagGroupContainer } from "./tag_group_container";
@@ -141,6 +141,14 @@ export class ObloggerView extends ItemView {
                 fileChanged: TFile,
                 fileContents: string,
                 fileMetadata: CachedMetadata
+            ) => {
+                this.requestRender();
+            })
+        );
+
+        this.registerEvent(
+            this.app.vault.on("create", (
+                itemCreated: TAbstractFile
             ) => {
                 this.requestRender();
             })

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -155,9 +155,11 @@ export class ObloggerView extends ItemView {
         );
 
         this.registerEvent(
-            this.app.workspace.on("file-open", (file) => {
-                if (file) {
-                    this.lastOpenFile = file;
+            this.app.workspace.on("file-open", (
+                fileOpened: TFile | null
+            ) => {
+                if (fileOpened) {
+                    this.lastOpenFile = fileOpened;
                     this.highlightLastOpenFile();
                 }
             })

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -157,14 +157,6 @@ export class ObloggerView extends ItemView {
         );
 
         this.registerEvent(
-            this.app.vault.on("modify", (
-                itemModified: TAbstractFile
-            ) => {
-                this.requestRender();
-            })
-        );
-
-        this.registerEvent(
             this.app.vault.on("rename", (
                 itemRenamed: TAbstractFile,
                 oldName: string

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -6,7 +6,7 @@ import {
     moment,
     Menu,
     View,
-    Notice
+    Notice, CachedMetadata
 } from "obsidian";
 import { ObloggerSettings, RxGroupType, OtcGroupSettings as SettingsTagGroup } from "./settings";
 import { TagGroupContainer } from "./tag_group_container";
@@ -134,6 +134,17 @@ export class ObloggerView extends ItemView {
         }
 
         this.lastOpenFile = this.app.workspace.getActiveFile() ?? undefined;
+
+
+        this.registerEvent(
+            this.app.metadataCache.on("changed", (
+                fileChanged: TFile,
+                fileContents: string,
+                fileMetadata: CachedMetadata
+            ) => {
+                this.requestRender();
+            })
+        );
 
         this.registerEvent(
             this.app.workspace.on("file-open", (file) => {

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -172,6 +172,14 @@ export class ObloggerView extends ItemView {
         );
 
         this.registerEvent(
+            this.app.vault.on("delete", (
+                itemDeleted: TAbstractFile
+            ) => {
+                this.requestRender();
+            })
+        );
+
+        this.registerEvent(
             this.app.workspace.on("file-open", (
                 fileOpened: TFile | null
             ) => {

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -6,7 +6,9 @@ import {
     moment,
     Menu,
     View,
-    Notice, CachedMetadata, TAbstractFile
+    Notice,
+    CachedMetadata,
+    TAbstractFile
 } from "obsidian";
 import { ObloggerSettings, RxGroupType, OtcGroupSettings as SettingsTagGroup } from "./settings";
 import { TagGroupContainer } from "./tag_group_container";

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -163,6 +163,15 @@ export class ObloggerView extends ItemView {
         );
 
         this.registerEvent(
+            this.app.vault.on("rename", (
+                itemRenamed: TAbstractFile,
+                oldName: string
+            ) => {
+                this.requestRender();
+            })
+        );
+
+        this.registerEvent(
             this.app.workspace.on("file-open", (
                 fileOpened: TFile | null
             ) => {

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -155,6 +155,14 @@ export class ObloggerView extends ItemView {
         );
 
         this.registerEvent(
+            this.app.vault.on("modify", (
+                itemModified: TAbstractFile
+            ) => {
+                this.requestRender();
+            })
+        );
+
+        this.registerEvent(
             this.app.workspace.on("file-open", (
                 fileOpened: TFile | null
             ) => {

--- a/src/recents_container.ts
+++ b/src/recents_container.ts
@@ -43,8 +43,7 @@ export class RecentsContainer extends ViewContainer {
     }
 
     protected shouldRerenderOnModification(
-        modifiedFile: FileModificationEventDetails,
-        excludedFolders: string[]
+        modifiedFile: FileModificationEventDetails
     ): boolean {
         // if the first of the sorted files isn't the modified file, then we
         // need to redraw.

--- a/src/recents_container.ts
+++ b/src/recents_container.ts
@@ -41,7 +41,10 @@ export class RecentsContainer extends ViewContainer {
         this.recentsCount = settings.recentsCount;
     }
 
-    protected shouldRerenderOnModification(modifiedFile: FileModificationEventDetails): boolean {
+    protected shouldRerenderOnModification(
+        modifiedFile: FileModificationEventDetails,
+        excludedFolders: string[]
+    ): boolean {
         // if the first of the sorted files isn't the modified file, then we
         // need to redraw.
         return this.sortedFiles[0] !== modifiedFile.file;

--- a/src/recents_container.ts
+++ b/src/recents_container.ts
@@ -2,6 +2,7 @@ import { FileClickCallback, FileAddedCallback } from "./group_folder";
 import { ViewContainer } from "./view_container";
 import { App, Menu } from "obsidian";
 import { ObloggerSettings, RxGroupType } from "./settings";
+import { FileModificationEventDetails } from "./constants";
 
 const RECENT_COUNT_OPTIONS = [5, 10, 15];
 
@@ -38,6 +39,11 @@ export class RecentsContainer extends ViewContainer {
             false); // isPinned
 
         this.recentsCount = settings.recentsCount;
+    }
+
+    protected shouldRerenderOnModification(modifiedFile: FileModificationEventDetails): boolean {
+        // todo: enhance
+        return true;
     }
 
     protected getEmptyMessage(): string {

--- a/src/recents_container.ts
+++ b/src/recents_container.ts
@@ -42,8 +42,9 @@ export class RecentsContainer extends ViewContainer {
     }
 
     protected shouldRerenderOnModification(modifiedFile: FileModificationEventDetails): boolean {
-        // todo: enhance
-        return true;
+        // if the first of the sorted files isn't the modified file, then we
+        // need to redraw.
+        return this.sortedFiles[0] !== modifiedFile.file;
     }
 
     protected getEmptyMessage(): string {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -55,8 +55,7 @@ export const PostLogAction = {
     COPY: "copy"
 }
 
-export interface ObloggerSettings {
-    version: number;
+interface ObloggerSettings_v0 {
     loggingPath: string;
     avatarPath: string;
     tagGroups: OtcGroupSettings[];
@@ -68,18 +67,28 @@ export interface ObloggerSettings {
     dailiesTag: string;
 }
 
-const UPGRADE_FUNCTIONS: {[id: number]: (settings: any)=> void} = {
-    0: (settings: any) => {
-        settings.version = 1;
+interface ObloggerSettings_v1 extends ObloggerSettings_v0 {
+    version: number;
+}
+
+export type ObloggerSettings = ObloggerSettings_v1
+
+const UPGRADE_FUNCTIONS: {[id: number]: (settings: ObloggerSettings) => void } = {
+    0: (settings: ObloggerSettings) => {
+        const newSettings = settings as ObloggerSettings_v1;
+        if (newSettings) {
+            newSettings.version = 1;
+        }
     }
 };
 
-export const upgradeSettings = (currentVersion: number, settings: any) => {
+export const upgradeSettings = (currentVersion: number, settings: ObloggerSettings) => {
     const availableUpgrades = Object.keys(UPGRADE_FUNCTIONS);
     if (!availableUpgrades.contains(currentVersion.toString())) {
         console.warn(`Unable to upgrade ${currentVersion}. No upgrade function defined.`)
         return;
     }
+
     UPGRADE_FUNCTIONS[currentVersion](settings);
 }
 

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -50,11 +50,9 @@ export class TagGroupContainer extends ViewContainer {
     }
 
     protected shouldRerenderOnModification(
-        modifiedFile: FileModificationEventDetails
+        modifiedFile: FileModificationEventDetails,
+        excludedFolders: string[]
     ): boolean {
-        // todo: get this from somewhere else
-        const excludedFolders: string[] = [];
-
         const currentFileTags = this.getFileTags(
             modifiedFile.file,
             excludedFolders,

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -172,10 +172,10 @@ export class TagGroupContainer extends ViewContainer {
 
             const setupItem = (item: MenuItem, method: string) => {
                 item.onClick(() => {
-                    changeSortMethod(method);
+                    return changeSortMethod(method);
                 });
                 if (method === this.getGroupSetting()?.sortMethod) {
-
+                    // Note: iconEl is added to MenuItem at run time
                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                     // @ts-ignore
                     item.iconEl.addClass("untagged-sort-confirmation");
@@ -238,11 +238,10 @@ export class TagGroupContainer extends ViewContainer {
         const isolatedGroupName = this.getIsolatedTagMatch()?.at(1);
 
         // This is fine, we're filtering out nulls
-        // @ts-ignore
         this.renderedFileTags = this.app.vault
             .getMarkdownFiles()
             .map(file => this.getFileTags(file, excludedFolders, isolatedGroupName))
-            .filter(item => item !== null);
+            .filter(item => item !== null) as FileTags[];
         return this.renderedFileTags
             .reduce((acc: TagFileMap, item: FileTags) => {
                 item.tags.forEach((tag: string) => {

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -77,11 +77,13 @@ export class TagGroupContainer extends ViewContainer {
             return true;
         }
 
-        const currentTags = currentFileTags?.tags;
-        // todo: O(n^2). better to compare lengths, sort both, then compare in O(n) => O(nlogn)
-        const currentTagsInCache = currentTags?.every(tag => fileTags.tags.contains(tag)) ?? false;
-        const cachedTagsInCurrent = fileTags.tags.every(tag => currentTags?.contains(tag)) ?? false;
-        return !currentTagsInCache || !cachedTagsInCurrent;
+        const currentTags = currentFileTags?.tags.sort();
+        if (currentTags?.length !== fileTags.tags.length) {
+            return true;
+        }
+        return fileTags.tags.sort().some((tag, index) => {
+            return tag !== currentTags.at(index);
+        });
     }
 
     protected getEmptyMessage(): string {

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -225,7 +225,7 @@ export class TagGroupContainer extends ViewContainer {
                 if (isolatedGroupName) {
                     return tag.contains(isolatedGroupName);
                 } else {
-                    return tag.split("/")[0] === this.groupName;
+                    return tag.startsWith(this.groupName);
                 }
             });
         if (!tags?.length) {

--- a/src/untagged_container.ts
+++ b/src/untagged_container.ts
@@ -72,19 +72,15 @@ export class UntaggedContainer extends ViewContainer {
         }
         // if we're sorting by modified and the modified time changed and
         // the file is not in the top or bottom depending on ordering, redraw
-        if (
-            renderedFile?.mtime !== modifiedFile.file.stat.mtime &&
-            this.getGroupSetting()?.sortMethod === ContainerSortMethod.MTIME &&
-            (
-                this.getGroupSetting()?.sortAscending ?
-                    this.renderedFiles.first() :
-                    this.renderedFiles.last()
-            )?.file !== modifiedFile.file
-        ) {
-            return true;
-        }
+        return renderedFile?.mtime !== modifiedFile.file.stat.mtime &&
+          this.getGroupSetting()?.sortMethod === ContainerSortMethod.MTIME &&
+          (
+            this.getGroupSetting()?.sortAscending ?
+              this.renderedFiles.first() :
+              this.renderedFiles.last()
+          )?.file !== modifiedFile.file;
 
-        return false;
+
     }
 
     protected getEmptyMessage(): string {
@@ -151,7 +147,7 @@ export class UntaggedContainer extends ViewContainer {
 
             const setupItem = (item: MenuItem, method: string) => {
                 item.onClick(() => {
-                    changeSortMethod(method);
+                    return changeSortMethod(method);
                 });
                 if (method === this.getGroupSetting()?.sortMethod) {
 

--- a/src/untagged_container.ts
+++ b/src/untagged_container.ts
@@ -35,7 +35,10 @@ export class UntaggedContainer extends ViewContainer {
             false); // isPinned
     }
 
-    protected shouldRerenderOnModification(modifiedFile: FileModificationEventDetails): boolean {
+    protected shouldRerenderOnModification(
+        modifiedFile: FileModificationEventDetails,
+        excludedFolders: string[]
+    ): boolean {
         // todo: enhance
         //  1. check if tag status changed
         //  2. check if modified time changed

--- a/src/untagged_container.ts
+++ b/src/untagged_container.ts
@@ -2,6 +2,7 @@ import { FileClickCallback, FileAddedCallback } from "./group_folder";
 import { ViewContainer } from "./view_container";
 import { App, getAllTags, Menu, MenuItem, moment, TFile } from "obsidian";
 import { ObloggerSettings, ContainerSortMethod, getSortMethodDisplayText, RxGroupType } from "./settings";
+import { FileModificationEventDetails } from "./constants";
 
 export class UntaggedContainer extends ViewContainer {
     constructor(
@@ -32,6 +33,11 @@ export class UntaggedContainer extends ViewContainer {
             false, // canBePinned
             undefined,
             false); // isPinned
+    }
+
+    protected shouldRerenderOnModification(modifiedFile: FileModificationEventDetails): boolean {
+        // todo: enhance
+        return true;
     }
 
     protected getEmptyMessage(): string {

--- a/src/untagged_container.ts
+++ b/src/untagged_container.ts
@@ -37,6 +37,9 @@ export class UntaggedContainer extends ViewContainer {
 
     protected shouldRerenderOnModification(modifiedFile: FileModificationEventDetails): boolean {
         // todo: enhance
+        //  1. check if tag status changed
+        //  2. check if modified time changed
+        //  3. check if created time changed
         return true;
     }
 

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -304,10 +304,7 @@ export abstract class ViewContainer extends GroupFolder {
         if (modifiedFiles.length > 0 && !modifiedFiles.some(
             f => this.shouldRerenderOnModification(f, excludedFolders))
         ) {
-            console.log(`ignoring render for ${this.groupName}`);
             return;
-        } else {
-            console.log(`rendering ${this.groupName}`);
         }
 
         this.rebuildFileStructure(excludedFolders);

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -1,6 +1,7 @@
 import { App, Menu, setIcon, TFile } from "obsidian";
 import { FileClickCallback, GroupFolder, FileAddedCallback } from "./group_folder";
 import { ObloggerSettings, RxGroupSettings } from "./settings";
+import { FileModificationEventDetails } from "./constants";
 
 export abstract class ViewContainer extends GroupFolder {
     settings: ObloggerSettings;
@@ -291,7 +292,11 @@ export abstract class ViewContainer extends GroupFolder {
         });
     }
 
-    public render(collapsedFolders: string[], excludedFolders: string[]) {
+    public render(
+        collapsedFolders: string[],
+        excludedFolders: string[],
+        modifiedFiles: FileModificationEventDetails[]
+    ) {
         this.rebuildFileStructure(excludedFolders);
 
         if (this.isVisible()) {

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -30,6 +30,7 @@ export abstract class ViewContainer extends GroupFolder {
     protected abstract getHideText(): string;
     protected abstract getHideIcon(): string;
     protected abstract getEmptyMessage(): string;
+    protected abstract shouldRerenderOnModification(modifiedFile: FileModificationEventDetails): boolean;
 
     protected constructor(
         app: App,
@@ -297,6 +298,13 @@ export abstract class ViewContainer extends GroupFolder {
         excludedFolders: string[],
         modifiedFiles: FileModificationEventDetails[]
     ) {
+        if (modifiedFiles.length > 0 && !modifiedFiles.some(f => this.shouldRerenderOnModification(f))) {
+            console.log(`ignoring render for ${this.groupName}`);
+            return;
+        } else {
+            console.log(`rendering ${this.groupName}`);
+        }
+
         this.rebuildFileStructure(excludedFolders);
 
         if (this.isVisible()) {

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -30,7 +30,10 @@ export abstract class ViewContainer extends GroupFolder {
     protected abstract getHideText(): string;
     protected abstract getHideIcon(): string;
     protected abstract getEmptyMessage(): string;
-    protected abstract shouldRerenderOnModification(modifiedFile: FileModificationEventDetails): boolean;
+    protected abstract shouldRerenderOnModification(
+        modifiedFile: FileModificationEventDetails,
+        excludedFolders: string[]
+    ): boolean;
 
     protected constructor(
         app: App,
@@ -298,7 +301,9 @@ export abstract class ViewContainer extends GroupFolder {
         excludedFolders: string[],
         modifiedFiles: FileModificationEventDetails[]
     ) {
-        if (modifiedFiles.length > 0 && !modifiedFiles.some(f => this.shouldRerenderOnModification(f))) {
+        if (modifiedFiles.length > 0 && !modifiedFiles.some(
+            f => this.shouldRerenderOnModification(f, excludedFolders))
+        ) {
             console.log(`ignoring render for ${this.groupName}`);
             return;
         } else {


### PR DESCRIPTION
fixes #76 

- adds a new abstract method to container views that takes in a file and returns whether or not modifications on that file will require the view to be redrawn
- implements the new abstract method differently on each view
- when files are modified, keep track of the modifications while we're waiting for the next render call and then send all of the files that were modified to each of the views and render them as needed. if a render call is made with now files modified then we assume that something substantial has changed and everything needs to be rendered. this might be the next source of performance improvements
- moves the event registers into the view instead of in main

there is a chance that a condition was missed on one of the views and it will incorrectly respond that it does not need to be rendered. in this case the behavior will be that the sidebar becomes out of date with the state of the vault. Something to keep an eye out for during testing