### PR TITLE
allow context-menu to render when called from a "skipped" note group

### DIFF
--- a/src/dailies_container.ts
+++ b/src/dailies_container.ts
@@ -1,5 +1,5 @@
 import { App, FrontMatterCache, getAllTags, Menu, moment, Notice, TFile } from "obsidian";
-import { FileClickCallback, FileAddedCallback } from "./group_folder";
+import { FileClickCallback, FileAddedCallback, FileRetainedCallback } from "./group_folder";
 import { ViewContainer } from "./view_container";
 import { ObloggerSettings, RxGroupType } from "./settings";
 import { NewTagModal } from "./new_tag_modal";
@@ -12,6 +12,7 @@ export class DailiesContainer extends ViewContainer {
         app: App,
         fileClickCallback: FileClickCallback,
         fileAddedCallback: FileAddedCallback,
+        fileRetainedCallback: FileRetainedCallback,
         collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
@@ -24,6 +25,7 @@ export class DailiesContainer extends ViewContainer {
             RxGroupType.DAILIES,
             fileClickCallback,
             fileAddedCallback,
+            fileRetainedCallback,
             collapseChangedCallback,
             false, // showStatusIcon
             requestRenderCallback,

--- a/src/files_container.ts
+++ b/src/files_container.ts
@@ -1,5 +1,5 @@
 import { ViewContainer } from "./view_container";
-import { FileAddedCallback, FileClickCallback } from "./group_folder";
+import { FileAddedCallback, FileClickCallback, FileRetainedCallback } from "./group_folder";
 import { ObloggerSettings, ContainerSortMethod, getSortMethodDisplayText, RxGroupType, getFileType } from "./settings";
 import { App, Menu, MenuItem, moment, TFile } from "obsidian";
 import { FileState } from "./constants";
@@ -9,6 +9,7 @@ export class FilesContainer extends ViewContainer {
         app: App,
         fileClickCallback: FileClickCallback,
         fileAddedCallback: FileAddedCallback,
+        fileRetainedCallback: FileRetainedCallback,
         collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
@@ -21,6 +22,7 @@ export class FilesContainer extends ViewContainer {
             RxGroupType.FILES,
             fileClickCallback,
             fileAddedCallback,
+            fileRetainedCallback,
             collapseChangedCallback,
             false,
             requestRenderCallback,

--- a/src/group_folder.ts
+++ b/src/group_folder.ts
@@ -16,6 +16,7 @@ export type FileAddedCallback = (
     contentItem: HTMLElement,
     titleItem: HTMLElement,
     titleContentItem: HTMLElement) => void;
+export type FileRetainedCallback =  (file: TFile) => void;
 
 declare module "obsidian" {
     interface Plugin {
@@ -92,7 +93,7 @@ export class GroupFolder {
     protected rebuild(
         collapsedFolders: string[],
         fileClickCallback: FileClickCallback,
-        fileAddedCallback: FileAddedCallback
+        fileAddedCallback: FileAddedCallback,
     ) {
         // Clear
         this.rootElement.empty();

--- a/src/recents_container.ts
+++ b/src/recents_container.ts
@@ -1,4 +1,4 @@
-import { FileClickCallback, FileAddedCallback } from "./group_folder";
+import {FileClickCallback, FileAddedCallback, FileRetainedCallback} from "./group_folder";
 import { ViewContainer } from "./view_container";
 import { App, Menu } from "obsidian";
 import { ObloggerSettings, RxGroupType } from "./settings";
@@ -13,6 +13,7 @@ export class RecentsContainer extends ViewContainer {
         app: App,
         fileClickCallback: FileClickCallback,
         fileAddedCallback: FileAddedCallback,
+        fileRetainedCallback: FileRetainedCallback,
         collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
@@ -25,6 +26,7 @@ export class RecentsContainer extends ViewContainer {
             RxGroupType.RECENTS,
             fileClickCallback,
             fileAddedCallback,
+            fileRetainedCallback,
             collapseChangedCallback,
             true,
             requestRenderCallback,

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -1,5 +1,5 @@
 import { App, getAllTags, Menu, MenuItem, TFile } from "obsidian";
-import { FileClickCallback, FileAddedCallback } from "./group_folder";
+import { FileClickCallback, FileAddedCallback, FileRetainedCallback } from "./group_folder";
 import { ViewContainer } from "./view_container";
 import { ContainerSortMethod, getSortMethodDisplayText, ObloggerSettings } from "./settings";
 import { FileState } from "./constants";
@@ -22,6 +22,7 @@ export class TagGroupContainer extends ViewContainer {
         moveCallback: (up: boolean) => void,
         fileClickCallback: FileClickCallback,
         fileAddedCallback: FileAddedCallback,
+        fileRetainedCallback: FileRetainedCallback,
         collapseChangedCallback: (baseTag: string, collapsedFolders: string[], save: boolean) => void,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
@@ -34,6 +35,7 @@ export class TagGroupContainer extends ViewContainer {
             baseTag,
             fileClickCallback,
             fileAddedCallback,
+            fileRetainedCallback,
             collapseChangedCallback,
             false,
             requestRenderCallback,

--- a/src/untagged_container.ts
+++ b/src/untagged_container.ts
@@ -1,4 +1,4 @@
-import { FileClickCallback, FileAddedCallback } from "./group_folder";
+import { FileClickCallback, FileAddedCallback, FileRetainedCallback } from "./group_folder";
 import { ViewContainer } from "./view_container";
 import { App, getAllTags, Menu, MenuItem, moment, TFile } from "obsidian";
 import { ObloggerSettings, ContainerSortMethod, getSortMethodDisplayText, RxGroupType } from "./settings";
@@ -17,6 +17,7 @@ export class UntaggedContainer extends ViewContainer {
         app: App,
         fileClickCallback: FileClickCallback,
         fileAddedCallback: FileAddedCallback,
+        fileRetainedCallback: FileRetainedCallback,
         collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
@@ -29,6 +30,7 @@ export class UntaggedContainer extends ViewContainer {
             RxGroupType.UNTAGGED,
             fileClickCallback,
             fileAddedCallback,
+            fileRetainedCallback,
             collapseChangedCallback,
             false,
             requestRenderCallback,

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -1,5 +1,5 @@
 import { App, FrontMatterCache, Menu, setIcon, TFile } from "obsidian";
-import { FileClickCallback, GroupFolder, FileAddedCallback } from "./group_folder";
+import {FileClickCallback, GroupFolder, FileAddedCallback, FileRetainedCallback} from "./group_folder";
 import { ObloggerSettings, RxGroupSettings } from "./settings";
 import { buildStateFromFile, FileState } from "./constants";
 
@@ -18,6 +18,7 @@ export abstract class ViewContainer extends GroupFolder {
 
     fileClickCallback: FileClickCallback;
     fileAddedCallback: FileAddedCallback;
+    fileRetainedCallback: FileRetainedCallback;
     requestRenderCallback: () => void;
     saveSettingsCallback: () => void;
     hideCallback: () => void;
@@ -48,6 +49,7 @@ export abstract class ViewContainer extends GroupFolder {
         viewName: string,
         fileClickCallback: FileClickCallback,
         fileAddedCallback: FileAddedCallback,
+        fileRetainedCallback: FileRetainedCallback,
         collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
         showStatusIcon: boolean,
         requestRenderCallback: () => void,
@@ -81,6 +83,7 @@ export abstract class ViewContainer extends GroupFolder {
 
         this.fileClickCallback = fileClickCallback;
         this.fileAddedCallback = fileAddedCallback;
+        this.fileRetainedCallback = fileRetainedCallback;
         this.requestRenderCallback = requestRenderCallback;
         this.saveSettingsCallback = saveSettingsCallback;
         this.hideCallback = hideCallback;
@@ -389,13 +392,18 @@ export abstract class ViewContainer extends GroupFolder {
     public render(
         collapsedFolders: string[],
         excludedFolders: string[],
-        modifiedFiles: FileState[]
+        modifiedFiles: FileState[],
+        forced: boolean
     ) {
-        if (modifiedFiles.length > 0) {
+        if (!forced && modifiedFiles.length > 0) {
             if (!modifiedFiles.some(state => {
                 return this.shouldFileCauseRender(state, excludedFolders);
             })) {
                 console.log(`skipping rendering of ${this.groupName}`)
+
+                // before returning, we want to make sure the files are still handled by the view (for context menu interactions)
+                this.renderedFileCaches.forEach(cache => this.fileRetainedCallback(cache.file));
+
                 return;
             }
         }


### PR DESCRIPTION
this PR is still cursed. 
the workaround did allow for rendering the context-menu from "skipped" groups but the fix is inconsistent. it seems to NEVER work with the recents group and in the test vault it doesn't work with the dailies group.

an additional workaround was attempted that would allow "skipped" recents to access the context-menu but this fix did nothing to help the dailies group in the test vault.

when tested in a different vault it did seem to work fine regardless of group.

it is a mystery