### PR TITLE
#91: use less brittle (but less feature rich) file context menu

### DIFF
--- a/src/dailies_container.ts
+++ b/src/dailies_container.ts
@@ -1,5 +1,5 @@
 import { App, FrontMatterCache, getAllTags, Menu, moment, Notice, TFile } from "obsidian";
-import { FileClickCallback, FileAddedCallback, FileRetainedCallback } from "./group_folder";
+import { FileClickCallback, FileAddedCallback } from "./group_folder";
 import { ViewContainer } from "./view_container";
 import { ObloggerSettings, RxGroupType } from "./settings";
 import { NewTagModal } from "./new_tag_modal";
@@ -12,7 +12,6 @@ export class DailiesContainer extends ViewContainer {
         app: App,
         fileClickCallback: FileClickCallback,
         fileAddedCallback: FileAddedCallback,
-        fileRetainedCallback: FileRetainedCallback,
         collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
@@ -25,7 +24,6 @@ export class DailiesContainer extends ViewContainer {
             RxGroupType.DAILIES,
             fileClickCallback,
             fileAddedCallback,
-            fileRetainedCallback,
             collapseChangedCallback,
             false, // showStatusIcon
             requestRenderCallback,

--- a/src/files_container.ts
+++ b/src/files_container.ts
@@ -1,5 +1,5 @@
 import { ViewContainer } from "./view_container";
-import { FileAddedCallback, FileClickCallback, FileRetainedCallback } from "./group_folder";
+import { FileAddedCallback, FileClickCallback } from "./group_folder";
 import { ObloggerSettings, ContainerSortMethod, getSortMethodDisplayText, RxGroupType, getFileType } from "./settings";
 import { App, Menu, MenuItem, moment, TFile } from "obsidian";
 import { FileState } from "./constants";
@@ -9,7 +9,6 @@ export class FilesContainer extends ViewContainer {
         app: App,
         fileClickCallback: FileClickCallback,
         fileAddedCallback: FileAddedCallback,
-        fileRetainedCallback: FileRetainedCallback,
         collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
@@ -22,7 +21,6 @@ export class FilesContainer extends ViewContainer {
             RxGroupType.FILES,
             fileClickCallback,
             fileAddedCallback,
-            fileRetainedCallback,
             collapseChangedCallback,
             false,
             requestRenderCallback,

--- a/src/group_folder.ts
+++ b/src/group_folder.ts
@@ -13,10 +13,7 @@ const COLLAPSED_CLASS_IDENTIFIER = "collapsed";
 export type FileClickCallback = (file: TFile) => void;
 export type FileAddedCallback = (
     file: TFile,
-    contentItem: HTMLElement,
-    titleItem: HTMLElement,
-    titleContentItem: HTMLElement) => void;
-export type FileRetainedCallback =  (file: TFile) => void;
+    contentItem: HTMLElement) => void;
 
 declare module "obsidian" {
     interface Plugin {
@@ -284,9 +281,8 @@ Created at ${window.moment(file.stat.ctime).format("YYYY-MM-DD HH:mm")}`;
 
         root_childItem.setAttribute("data-path", file.path);
 
-        // This callback is because we're leveraging the build in FileExplorer's
-        // context menu. It needs to know all files that might be clicked.
-        fileAddedCallback(file, root_childItem, childItemText, bookmarkIcon);
+        // This callback is here to handle context menu building at the view level
+        fileAddedCallback(file, root_childItem);
 
         return root_childItem;
     }

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -5,7 +5,6 @@ import {
     ButtonComponent,
     moment,
     Menu,
-    View,
     Notice,
     CachedMetadata
 } from "obsidian";
@@ -30,41 +29,6 @@ declare module "obsidian" {
         loadLocalStorage(key: string): string | null;
         saveLocalStorage(key: string, value: string | undefined): void;
     }
-}
-
-// Needed for using built-in context menu
-class FileItem {
-    titleEl: HTMLElement;
-    el: HTMLElement;
-    titleInnerEl: HTMLElement;
-    file: TFile;
-    selfEl: HTMLElement;
-
-    constructor(
-        file: TFile,
-        el: HTMLElement,
-        titleEl: HTMLElement,
-        titleInnerEl: HTMLElement
-    ) {
-        this.el = el;
-        this.file = file;
-        this.titleEl = titleEl;
-        this.titleInnerEl = titleInnerEl;
-
-        // not sure if this is the right thing to set it to
-        this.selfEl = el;
-    }
-}
-
-// Needed for using built-in context menu
-class UnknownInfinityScrollObject {
-    computeSync: () => void;
-    scrollIntoView: () => void;
-}
-
-// Needed for using built-in context menu
-class UnknownDomObject {
-    infinityScroll: UnknownInfinityScrollObject;
 }
 
 interface TagGroup {
@@ -94,10 +58,7 @@ export class ObloggerView extends ItemView {
     fileClickCallback: (file: TFile) => void;
     fileAddedCallback: (
         file: TFile,
-        contentItem: HTMLElement,
-        titleItem: HTMLDivElement,
-        titleContentItem: HTMLElement) => void;
-    fileRetainedCallback: (file: TFile) => void;
+        contentItem: HTMLElement) => void;
     rxGroupCollapseChangeCallback: (
         groupName: string,
         collapsedFolders: string[],
@@ -108,19 +69,6 @@ export class ObloggerView extends ItemView {
         collapsedFolders: string[],
         save: boolean
     ) => void;
-
-    // Needed so we can pull old data to retain during a render cycle
-    oldFileItems: {[id: string]: FileItem};
-
-    // These are needed for the context menu to work
-    files: WeakMap<HTMLElement, TFile>;
-    fileItems: {[id: string]: FileItem};
-    selectedDoms: [];
-    dom: UnknownDomObject;
-    openFileContextMenu: (e: MouseEvent, container: HTMLDivElement) => void;
-    setFocusedItem: (fileItem: FileItem) => void;
-    afterCreate: (file: TFile, unknownBool: boolean) => void;
-    isItem: (file: TFile) => boolean;
 
     constructor(
         leaf: WorkspaceLeaf,
@@ -133,19 +81,8 @@ export class ObloggerView extends ItemView {
         this.fullRender = true;
         this.settings = settings;
         this.showLoggerCallbackFn = showLoggerCallbackFn;
-        this.files = new WeakMap();
-        this.selectedDoms = [];
-        this.fileItems = {};
-        this.oldFileItems = {};
         this.otcGroups = [];
         this.saveSettingsCallback = saveSettingsCallback;
-
-        class FileExplorerLeaf extends WorkspaceLeaf {}
-        interface FileExplorerView extends View {
-            openFileContextMenu: (e: MouseEvent, container: HTMLDivElement) => void;
-            setFocusedItem: (fileItem: FileItem) => void;
-            afterCreate: (file: TFile, unknownBool: boolean) => void;
-        }
 
         this.lastOpenFile = this.app.workspace.getActiveFile() ?? undefined;
 
@@ -196,22 +133,14 @@ export class ObloggerView extends ItemView {
 
         this.fileAddedCallback = (
             file: TFile,
-            contentItem: HTMLElement,
-            titleItem: HTMLDivElement,
-            titleContentItem: HTMLElement
+            contentItem: HTMLElement
         ) => {
-            this.files.set(contentItem, file);
-            this.fileItems[file.path] = new FileItem(file, contentItem, titleItem, titleContentItem);
             contentItem.addEventListener("contextmenu", (e) => {
                 const menu = new Menu();
-                this.app.workspace.trigger(
-                    "file-menu",
-                    menu,
-                    file,
-                    "file-explorer"
-                );
 
                 menu.addSeparator();
+
+                // todo: set proper category so this shows up in the right place
                 menu.addItem((item) =>
                     item
                         .setTitle(`Open in new tab`)
@@ -220,6 +149,8 @@ export class ObloggerView extends ItemView {
                             return app.workspace.openLinkText(file.path, file.path, "tab");
                         })
                 );
+
+                // todo: set proper category so this shows up in the right place
                 menu.addItem((item) =>
                     item
                         .setTitle(`Open to the right`)
@@ -228,6 +159,13 @@ export class ObloggerView extends ItemView {
                             return app.workspace.openLinkText(file.path, file.path, "split");
                         })
                 );
+
+                // This adds all the normal file-explorer stuff
+                this.app.workspace.trigger(
+                    "file-menu",
+                    menu,
+                    file,
+                    "file-explorer");
 
                 if ("screenX" in e) {
                     menu.showAtPosition({ x: e.pageX, y: e.pageY });
@@ -242,16 +180,6 @@ export class ObloggerView extends ItemView {
                     });
                 }
             });
-        }
-
-        this.fileRetainedCallback = (file: TFile) => {
-            const fileItem = this.oldFileItems[file.path];
-
-            const contentItem = fileItem.el;
-            const titleItem = fileItem.titleEl as HTMLDivElement;
-            const titleContentItem = fileItem.titleInnerEl;
-            this.files.set(contentItem, file);
-            this.fileItems[file.path] = new FileItem(file, contentItem, titleItem, titleContentItem);
         }
 
         this.rxGroupCollapseChangeCallback = (
@@ -288,46 +216,7 @@ export class ObloggerView extends ItemView {
             return this.saveSettingsCallback();
         }
 
-        this.dom = {
-            infinityScroll: {
-                computeSync: () => { console.debug("computeSync does nothing"); },
-                scrollIntoView: () => { console.debug("scrollIntoView does nothing"); }
-            }
-        }
-
         this.app.workspace.onLayoutReady(() => {
-            // Hook up to the file-explorer plugin
-            const fileExplorerLeaf = this.app.workspace.getLeavesOfType("file-explorer")[0] as FileExplorerLeaf;
-            const fileExplorer = fileExplorerLeaf?.view as FileExplorerView;
-            this.openFileContextMenu = fileExplorer.openFileContextMenu;
-            this.setFocusedItem = fileExplorer.setFocusedItem;
-            this.afterCreate = fileExplorer.afterCreate;
-            this.isItem = () => false;
-
-            this.registerEvent(
-                // todo(#172): right now, we're disabling rename because it's broken
-                //  however, we should fix it with either custom rename or by getting
-                //  the in-line rename to work right
-                this.app.workspace.on("file-menu", (menu) => {
-                    // Don't hide it for other views (like file-explorer)
-                    if(!this.app.workspace.getActiveViewOfType(ObloggerView)?.getState()) {
-                        return;
-                    }
-                    // These types are added at run-time on top of Menu? Or Menu is
-                    // the wrong type to be using and these are already defined
-                    // somewhere.
-                    class FileMenuAction {
-                        titleEl: HTMLElement;
-                    }
-                    class FileMenu extends Menu {
-                        items: FileMenuAction[]
-                    }
-                    const fileMenu = menu as FileMenu;
-                    const renameAction = fileMenu.items.find(i => i?.titleEl?.innerHTML === "Rename");
-                    renameAction && fileMenu.items.remove(renameAction);
-                })
-            );
-
             // Hook up to the bookmarks plugin
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
@@ -454,10 +343,6 @@ export class ObloggerView extends ItemView {
     }
 
     private async renderNow(modifiedFiles: FileState[]) {
-        this.files = new WeakMap();
-        this.oldFileItems = this.fileItems;
-        this.fileItems = {};
-
         await this.renderAvatar();
         await this.renderVault();
         this.renderClock(this.clockDiv);
@@ -838,7 +723,6 @@ export class ObloggerView extends ItemView {
             moveCallback,
             this.fileClickCallback,
             this.fileAddedCallback,
-            this.fileRetainedCallback,
             this.tagGroupCollapseChangedCallback,
             () => { this.requestRender() },
             this.settings,
@@ -858,8 +742,6 @@ export class ObloggerView extends ItemView {
         this.otcGroupsDiv?.empty();
 
         this.otcGroups = [];
-        this.files = new WeakMap();
-        this.fileItems = {};
 
         const groupSorter = (a: SettingsTagGroup, b: SettingsTagGroup): number => {
             const pattern = "\\.\\.\\./(.*)/\\.\\.\\.";
@@ -931,7 +813,6 @@ export class ObloggerView extends ItemView {
                 this.app,
                 this.fileClickCallback,
                 this.fileAddedCallback,
-                this.fileRetainedCallback,
                 this.rxGroupCollapseChangeCallback,
                 () => { this.requestRender() },
                 this.settings,

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -210,10 +210,12 @@ export class ObloggerView extends ItemView {
 
         this.fileRetainedCallback = (file: TFile) => {
             const fileItem = this.oldFileItems[file.path];
+
             const contentItem = fileItem.el;
             const titleItem = fileItem.titleEl as HTMLDivElement;
             const titleContentItem = fileItem.titleInnerEl;
-            this.fileAddedCallback(file, contentItem, titleItem, titleContentItem);
+            this.files.set(contentItem, file);
+            this.fileItems[file.path] = new FileItem(file, contentItem, titleItem, titleContentItem);
         }
 
         this.rxGroupCollapseChangeCallback = (

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -140,20 +140,20 @@ export class ObloggerView extends ItemView {
 
                 menu.addSeparator();
 
-                // todo(#96): set proper category so this shows up in the right place
                 menu.addItem((item) =>
                     item
                         .setTitle(`Open in new tab`)
+                        .setSection("open")
                         .setIcon("lucide-file-plus")
                         .onClick(async () => {
                             return app.workspace.openLinkText(file.path, file.path, "tab");
                         })
                 );
 
-                // todo(#96): set proper category so this shows up in the right place
                 menu.addItem((item) =>
                     item
                         .setTitle(`Open to the right`)
+                        .setSection("open")
                         .setIcon("lucide-separator-vertical")
                         .onClick(async () => {
                             return app.workspace.openLinkText(file.path, file.path, "split");

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -203,8 +203,46 @@ export class ObloggerView extends ItemView {
             this.files.set(contentItem, file);
             this.fileItems[file.path] = new FileItem(file, contentItem, titleItem, titleContentItem);
             contentItem.addEventListener("contextmenu", (e) => {
-                // todo(#91): something in the openFileContextMenu is blocking the context menu in some vaults
-                this.openFileContextMenu(e, titleItem);
+                // // todo(#91): something in the openFileContextMenu is blocking the context menu in some vaults
+                // this.openFileContextMenu(e, titleItem);
+                const menu = new Menu();
+                this.app.workspace.trigger(
+                    "file-menu",
+                    menu,
+                    file,
+                    "file-explorer"
+                );
+
+                menu.addSeparator();
+                menu.addItem((item) =>
+                    item
+                        .setTitle(`Open in new tab`)
+                        .setIcon("lucide-file-plus")
+                        .onClick(async () => {
+                            app.workspace.openLinkText(file.path, file.path, "tab");
+                        })
+                );
+                menu.addItem((item) =>
+                    item
+                        .setTitle(`Open to the right`)
+                        .setIcon("lucide-separator-vertical")
+                        .onClick(async () => {
+                            app.workspace.openLinkText(file.path, file.path, "split");
+                        })
+                );
+
+                if ("screenX" in e) {
+                    menu.showAtPosition({ x: e.pageX, y: e.pageY });
+                } else {
+                    menu.showAtPosition({
+                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                        // @ts-ignore
+                        x: e.nativeEvent.locationX,
+                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                        // @ts-ignore
+                        y: e.nativeEvent.locationY,
+                    });
+                }
             });
         }
 

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -140,7 +140,7 @@ export class ObloggerView extends ItemView {
 
                 menu.addSeparator();
 
-                // todo: set proper category so this shows up in the right place
+                // todo(#96): set proper category so this shows up in the right place
                 menu.addItem((item) =>
                     item
                         .setTitle(`Open in new tab`)
@@ -150,7 +150,7 @@ export class ObloggerView extends ItemView {
                         })
                 );
 
-                // todo: set proper category so this shows up in the right place
+                // todo(#96): set proper category so this shows up in the right place
                 menu.addItem((item) =>
                     item
                         .setTitle(`Open to the right`)

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -394,7 +394,11 @@ export class ObloggerView extends ItemView {
     }
 
     private renderFiles(modifiedFiles: FileState[]) {
-        this.renderRxGroup(RxGroupType.FILES, [], modifiedFiles, false);
+        this.renderRxGroup(
+            RxGroupType.FILES,
+            [],
+            modifiedFiles,
+            false);
     }
 
     private renderUntagged(modifiedFiles: FileState[]) {
@@ -406,7 +410,11 @@ export class ObloggerView extends ItemView {
     }
 
     private renderRecents(modifiedFiles: FileState[]) {
-        this.renderRxGroup(RxGroupType.RECENTS, [], modifiedFiles, true);
+        this.renderRxGroup(
+            RxGroupType.RECENTS,
+            [],
+            modifiedFiles,
+            false);
     }
 
     private async renderNow(modifiedFiles: FileState[]) {

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -203,8 +203,6 @@ export class ObloggerView extends ItemView {
             this.files.set(contentItem, file);
             this.fileItems[file.path] = new FileItem(file, contentItem, titleItem, titleContentItem);
             contentItem.addEventListener("contextmenu", (e) => {
-                // // todo(#91): something in the openFileContextMenu is blocking the context menu in some vaults
-                // this.openFileContextMenu(e, titleItem);
                 const menu = new Menu();
                 this.app.workspace.trigger(
                     "file-menu",
@@ -219,7 +217,7 @@ export class ObloggerView extends ItemView {
                         .setTitle(`Open in new tab`)
                         .setIcon("lucide-file-plus")
                         .onClick(async () => {
-                            app.workspace.openLinkText(file.path, file.path, "tab");
+                            return app.workspace.openLinkText(file.path, file.path, "tab");
                         })
                 );
                 menu.addItem((item) =>
@@ -227,7 +225,7 @@ export class ObloggerView extends ItemView {
                         .setTitle(`Open to the right`)
                         .setIcon("lucide-separator-vertical")
                         .onClick(async () => {
-                            app.workspace.openLinkText(file.path, file.path, "split");
+                            return app.workspace.openLinkText(file.path, file.path, "split");
                         })
                 );
 

--- a/src/recents_container.ts
+++ b/src/recents_container.ts
@@ -1,4 +1,4 @@
-import {FileClickCallback, FileAddedCallback, FileRetainedCallback} from "./group_folder";
+import {FileClickCallback, FileAddedCallback } from "./group_folder";
 import { ViewContainer } from "./view_container";
 import { App, Menu } from "obsidian";
 import { ObloggerSettings, RxGroupType } from "./settings";
@@ -13,7 +13,6 @@ export class RecentsContainer extends ViewContainer {
         app: App,
         fileClickCallback: FileClickCallback,
         fileAddedCallback: FileAddedCallback,
-        fileRetainedCallback: FileRetainedCallback,
         collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
@@ -26,7 +25,6 @@ export class RecentsContainer extends ViewContainer {
             RxGroupType.RECENTS,
             fileClickCallback,
             fileAddedCallback,
-            fileRetainedCallback,
             collapseChangedCallback,
             true,
             requestRenderCallback,

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -1,5 +1,5 @@
 import { App, getAllTags, Menu, MenuItem, TFile } from "obsidian";
-import { FileClickCallback, FileAddedCallback, FileRetainedCallback } from "./group_folder";
+import { FileClickCallback, FileAddedCallback } from "./group_folder";
 import { ViewContainer } from "./view_container";
 import { ContainerSortMethod, getSortMethodDisplayText, ObloggerSettings } from "./settings";
 import { FileState } from "./constants";
@@ -22,7 +22,6 @@ export class TagGroupContainer extends ViewContainer {
         moveCallback: (up: boolean) => void,
         fileClickCallback: FileClickCallback,
         fileAddedCallback: FileAddedCallback,
-        fileRetainedCallback: FileRetainedCallback,
         collapseChangedCallback: (baseTag: string, collapsedFolders: string[], save: boolean) => void,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
@@ -35,7 +34,6 @@ export class TagGroupContainer extends ViewContainer {
             baseTag,
             fileClickCallback,
             fileAddedCallback,
-            fileRetainedCallback,
             collapseChangedCallback,
             false,
             requestRenderCallback,

--- a/src/untagged_container.ts
+++ b/src/untagged_container.ts
@@ -1,4 +1,4 @@
-import { FileClickCallback, FileAddedCallback, FileRetainedCallback } from "./group_folder";
+import { FileClickCallback, FileAddedCallback } from "./group_folder";
 import { ViewContainer } from "./view_container";
 import { App, getAllTags, Menu, MenuItem, moment, TFile } from "obsidian";
 import { ObloggerSettings, ContainerSortMethod, getSortMethodDisplayText, RxGroupType } from "./settings";
@@ -17,7 +17,6 @@ export class UntaggedContainer extends ViewContainer {
         app: App,
         fileClickCallback: FileClickCallback,
         fileAddedCallback: FileAddedCallback,
-        fileRetainedCallback: FileRetainedCallback,
         collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
@@ -30,7 +29,6 @@ export class UntaggedContainer extends ViewContainer {
             RxGroupType.UNTAGGED,
             fileClickCallback,
             fileAddedCallback,
-            fileRetainedCallback,
             collapseChangedCallback,
             false,
             requestRenderCallback,

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -1,5 +1,5 @@
 import { App, FrontMatterCache, Menu, setIcon, TFile } from "obsidian";
-import {FileClickCallback, GroupFolder, FileAddedCallback, FileRetainedCallback} from "./group_folder";
+import {FileClickCallback, GroupFolder, FileAddedCallback} from "./group_folder";
 import { ObloggerSettings, RxGroupSettings } from "./settings";
 import { buildStateFromFile, FileState } from "./constants";
 
@@ -18,7 +18,6 @@ export abstract class ViewContainer extends GroupFolder {
 
     fileClickCallback: FileClickCallback;
     fileAddedCallback: FileAddedCallback;
-    fileRetainedCallback: FileRetainedCallback;
     requestRenderCallback: () => void;
     saveSettingsCallback: () => void;
     hideCallback: () => void;
@@ -49,7 +48,6 @@ export abstract class ViewContainer extends GroupFolder {
         viewName: string,
         fileClickCallback: FileClickCallback,
         fileAddedCallback: FileAddedCallback,
-        fileRetainedCallback: FileRetainedCallback,
         collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
         showStatusIcon: boolean,
         requestRenderCallback: () => void,
@@ -83,7 +81,6 @@ export abstract class ViewContainer extends GroupFolder {
 
         this.fileClickCallback = fileClickCallback;
         this.fileAddedCallback = fileAddedCallback;
-        this.fileRetainedCallback = fileRetainedCallback;
         this.requestRenderCallback = requestRenderCallback;
         this.saveSettingsCallback = saveSettingsCallback;
         this.hideCallback = hideCallback;
@@ -400,10 +397,6 @@ export abstract class ViewContainer extends GroupFolder {
                 return this.shouldFileCauseRender(state, excludedFolders);
             })) {
                 console.log(`skipping rendering of ${this.groupName}`)
-
-                // before returning, we want to make sure the files are still handled by the view (for context menu interactions)
-                this.renderedFileCaches.forEach(cache => this.fileRetainedCallback(cache.file));
-
                 return;
             }
         }


### PR DESCRIPTION
fixes #91 
fixes #94 
fixes #96

regresses on the file context menu losing
- some organization of options
- `Make a copy` item
- `Delete` item