### PR TITLE
#47: UI for excluding folders

### DIFF
--- a/src/dailies_container.ts
+++ b/src/dailies_container.ts
@@ -15,7 +15,7 @@ export class DailiesContainer extends ViewContainer {
         collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => void,
+        saveSettingsCallback: () => Promise<void>,
         moveCallback: (up: boolean) => void,
         hideCallback: () => void
     ) {

--- a/src/files_container.ts
+++ b/src/files_container.ts
@@ -12,7 +12,7 @@ export class FilesContainer extends ViewContainer {
         collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => void,
+        saveSettingsCallback: () => Promise<void>,
         moveCallback: (up: boolean) => void,
         hideCallback: () => void
     ) {

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -288,19 +288,9 @@ export class ObloggerView extends ItemView {
             if (!maybeSettingsGroup.templatesFolderVisible) {
                 const templatesFolderPath = ""; // todo: figure out how to get this
                 excludedFolders.push(templatesFolderPath);
-
-                // todo: validate that pushing new things to excluded folders doesn't modify the settings object
-                if (excludedFolders === maybeSettingsGroup.excludedFolders) {
-                    console.error("this isn't supposed to happen. program it differently!")
-                }
             }
             if (!maybeSettingsGroup.logsFolderVisible && this.settings) {
                 excludedFolders.push(this.settings.loggingPath);
-
-                // todo: validate that pushing new things to excluded folders doesn't modify the settings object
-                if (excludedFolders === maybeSettingsGroup.excludedFolders) {
-                    console.error("this isn't supposed to happen. program it differently!")
-                }
             }
         }
 
@@ -323,19 +313,9 @@ export class ObloggerView extends ItemView {
         if (!groupSetting.templatesFolderVisible) {
             const templatesFolderPath = ""; // todo: figure out how to get this
             excludedFolders.push(templatesFolderPath);
-
-            // todo: validate that pushing new things to excluded folders doesn't modify the settings object
-            if (excludedFolders === groupSetting.excludedFolders) {
-                console.error("this isn't supposed to happen. program it differently!")
-            }
         }
         if (!groupSetting.logsFolderVisible && this.settings) {
             excludedFolders.push(this.settings.loggingPath);
-
-            // todo: validate that pushing new things to excluded folders doesn't modify the settings object
-            if (excludedFolders === groupSetting.excludedFolders) {
-                console.error("this isn't supposed to happen. program it differently!")
-            }
         }
         const container = this.rxContainers.find(container => container.groupName === groupName);
         if (!container) {

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -277,6 +277,29 @@ export class ObloggerView extends ItemView {
         this.registerInterval(this.renderTimeout);
     }
 
+    private getTemplatesFolders(): string[] {
+        const templatesFolders: string[] = []
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const coreTemplatesFolder = this.app.internalPlugins.plugins["templates"]?.instance?.options?.folder ?? "";
+        if (coreTemplatesFolder !== "") {
+            console.log(coreTemplatesFolder);
+            templatesFolders.push(coreTemplatesFolder);
+        }
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const templaterFolder = this.app.plugins.plugins["templater-obsidian"]?.settings?.templates_folder ?? "";
+        if (templaterFolder !== "") {
+            console.log(templaterFolder);
+            templatesFolders.push(templaterFolder);
+        }
+
+        console.log(templatesFolders);
+        return templatesFolders;
+    }
+
     private renderTagGroup(group: GroupFolder, modifiedFiles: FileState[]) {
         const maybeSettingsGroup = this.settings?.tagGroups.find(
             settingsGroup => settingsGroup.tag === group.groupName
@@ -286,8 +309,7 @@ export class ObloggerView extends ItemView {
         const excludedFolders = [...maybeSettingsGroup?.excludedFolders ?? []];
         if (maybeSettingsGroup) {
             if (!maybeSettingsGroup.templatesFolderVisible) {
-                const templatesFolderPath = ""; // todo: figure out how to get this
-                excludedFolders.push(templatesFolderPath);
+                excludedFolders.push(...this.getTemplatesFolders());
             }
             if (!maybeSettingsGroup.logsFolderVisible && this.settings) {
                 excludedFolders.push(this.settings.loggingPath);
@@ -311,8 +333,7 @@ export class ObloggerView extends ItemView {
         }
         const excludedFolders = [...groupSetting.excludedFolders];
         if (!groupSetting.templatesFolderVisible) {
-            const templatesFolderPath = ""; // todo: figure out how to get this
-            excludedFolders.push(templatesFolderPath);
+            excludedFolders.push(...this.getTemplatesFolders());
         }
         if (!groupSetting.logsFolderVisible && this.settings) {
             excludedFolders.push(this.settings.loggingPath);

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -504,7 +504,10 @@ export class ObloggerView extends ItemView {
             this.settings.tagGroups.push({
                 tag: result,
                 collapsedFolders: [],
-                isPinned: false
+                isPinned: false,
+                excludedFolders: [],
+                logsFolderVisible: false,
+                templatesFolderVisible: false
             });
             await this.saveSettingsCallback();
             this.reloadOtcGroups();

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -284,19 +284,14 @@ export class ObloggerView extends ItemView {
         // @ts-ignore
         const coreTemplatesFolder = this.app.internalPlugins.plugins["templates"]?.instance?.options?.folder ?? "";
         if (coreTemplatesFolder !== "") {
-            console.log(coreTemplatesFolder);
             templatesFolders.push(coreTemplatesFolder);
         }
-
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         const templaterFolder = this.app.plugins.plugins["templater-obsidian"]?.settings?.templates_folder ?? "";
         if (templaterFolder !== "") {
-            console.log(templaterFolder);
             templatesFolders.push(templaterFolder);
         }
-
-        console.log(templatesFolders);
         return templatesFolders;
     }
 

--- a/src/recents_container.ts
+++ b/src/recents_container.ts
@@ -16,7 +16,7 @@ export class RecentsContainer extends ViewContainer {
         collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => void,
+        saveSettingsCallback: () => Promise<void>,
         moveCallback: (up: boolean) => void,
         hideCallback: () => void
     ) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -136,10 +136,13 @@ const UPGRADE_FUNCTIONS: {[id: number]: (settings: ObloggerSettings) => void } =
                     RxGroupType.FILES,
                     RxGroupType.RECENTS
                 ].contains(group.groupName);
+
+                group.excludedFolders = [];
             });
             newSettings.tagGroups.forEach(group => {
                 group.logsFolderVisible = false;
                 group.templatesFolderVisible = false;
+                group.excludedFolders = [];
             });
             newSettings.version = 3;
         }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -126,8 +126,16 @@ const UPGRADE_FUNCTIONS: {[id: number]: (settings: ObloggerSettings) => void } =
         const newSettings = settings as ObloggerSettings_v3;
         if (newSettings) {
             newSettings.rxGroups.forEach(group => {
-                group.logsFolderVisible = false;
-                group.templatesFolderVisible = false;
+                group.logsFolderVisible = [
+                    RxGroupType.DAILIES,
+                    RxGroupType.FILES,
+                    RxGroupType.RECENTS
+                ].contains(group.groupName);
+
+                group.templatesFolderVisible = [
+                    RxGroupType.FILES,
+                    RxGroupType.RECENTS
+                ].contains(group.groupName);
             });
             newSettings.tagGroups.forEach(group => {
                 group.logsFolderVisible = false;
@@ -169,7 +177,7 @@ export const DEFAULT_SETTINGS: ObloggerSettings = {
             isVisible: true,
             sortMethod: ContainerSortMethod.ALPHABETICAL,
             sortAscending: true,
-            logsFolderVisible: false,
+            logsFolderVisible: true,
             templatesFolderVisible: false,
             excludedFolders: []
         },
@@ -179,8 +187,8 @@ export const DEFAULT_SETTINGS: ObloggerSettings = {
             isVisible: true,
             sortMethod: ContainerSortMethod.TYPE,
             sortAscending: true,
-            logsFolderVisible: false,
-            templatesFolderVisible: false,
+            logsFolderVisible: true,
+            templatesFolderVisible: true,
             excludedFolders: []
         },
         {
@@ -189,8 +197,8 @@ export const DEFAULT_SETTINGS: ObloggerSettings = {
             isVisible: true,
             sortMethod: ContainerSortMethod.ALPHABETICAL,
             sortAscending: true,
-            logsFolderVisible: false,
-            templatesFolderVisible: false,
+            logsFolderVisible: true,
+            templatesFolderVisible: true,
             excludedFolders: []
         },
         {

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -25,7 +25,7 @@ export class TagGroupContainer extends ViewContainer {
         collapseChangedCallback: (baseTag: string, collapsedFolders: string[], save: boolean) => void,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => void,
+        saveSettingsCallback: () => Promise<void>,
         pinCallback: (pin: boolean) => void,
         isPinned: boolean
     ) {

--- a/src/untagged_container.ts
+++ b/src/untagged_container.ts
@@ -20,7 +20,7 @@ export class UntaggedContainer extends ViewContainer {
         collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => void,
+        saveSettingsCallback: () => Promise<void>,
         moveCallback: (up: boolean) => void,
         hideCallback: () => void
     ) {

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -163,6 +163,41 @@ export abstract class ViewContainer extends GroupFolder {
             );
         }
 
+        menu.addItem(item => {
+            item
+                .setTitle("Folder exclusions")
+                .setSection("exclusions")
+                .setIcon("folder-x");
+
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore
+            const subMenu = item.setSubmenu() as Menu;
+            subMenu.addItem(subItem => {
+                subItem
+                    .setTitle("Hide templates")
+                    .setIcon("eye-off")
+                    .setSection("hide");
+            });
+            subMenu.addItem(subItem => {
+                subItem
+                    .setTitle("Show logs")
+                    .setIcon("eye")
+                    .setSection("hide");
+            });
+            subMenu.addItem(subItem => {
+                subItem
+                    .setTitle("Include asdf")
+                    .setIcon("folder-plus")
+                    .setSection("include");
+            });
+            subMenu.addItem(subItem => {
+                subItem
+                    .setTitle("Exclude folder")
+                    .setIcon("folder-x")
+                    .setSection("exclude");
+            });
+        });
+
         menu.addItem(item =>
             item
                 .setTitle(this.getHideText())

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -180,20 +180,44 @@ export abstract class ViewContainer extends GroupFolder {
                 subItem
                     .setTitle(`${groupSetting?.templatesFolderVisible ? "Hide" : "Show"} templates`)
                     .setIcon(groupSetting?.templatesFolderVisible ? "eye-off" : "eye")
-                    .setSection("hide");
+                    .setSection("hide")
+                    .onClick(() => {
+                        if (groupSetting) {
+                            groupSetting.templatesFolderVisible = !groupSetting.templatesFolderVisible;
+                            this.saveSettingsCallback();
+                        } else {
+                            console.warn(`Unable to get group setting for ${this.groupName}`)
+                        }
+                    });
             });
             subMenu.addItem(subItem => {
                 subItem
                     .setTitle(`${groupSetting?.logsFolderVisible ? "Hide" : "Show"} logs`)
                     .setIcon(groupSetting?.logsFolderVisible ? "eye-off" : "eye")
-                    .setSection("hide");
+                    .setSection("hide")
+                    .onClick(() => {
+                        if (groupSetting) {
+                            groupSetting.logsFolderVisible = !groupSetting.logsFolderVisible;
+                            this.saveSettingsCallback();
+                        } else {
+                            console.warn(`Unable to get group setting for ${this.groupName}`)
+                        }
+                    });
             });
             groupSetting?.excludedFolders.forEach(folderPath => {
                 subMenu.addItem(subItem => {
                     subItem
                         .setTitle(`Include ${folderPath}`)
                         .setIcon("folder-plus")
-                        .setSection("include");
+                        .setSection("include")
+                        .onClick(() => {
+                            if (groupSetting) {
+                                groupSetting.excludedFolders.remove(folderPath);
+                                this.saveSettingsCallback();
+                            } else {
+                                console.warn(`Unable to get group setting for ${this.groupName}`)
+                            }
+                        });
                 });
             });
             subMenu.addItem(subItem => {

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -182,10 +182,11 @@ export abstract class ViewContainer extends GroupFolder {
                     .setTitle(`${groupSetting?.templatesFolderVisible ? "Hide" : "Show"} templates`)
                     .setIcon(groupSetting?.templatesFolderVisible ? "eye-off" : "eye")
                     .setSection("hide")
-                    .onClick(() => {
+                    .onClick(async () => {
                         if (groupSetting) {
                             groupSetting.templatesFolderVisible = !groupSetting.templatesFolderVisible;
-                            this.saveSettingsCallback();
+                            await this.saveSettingsCallback();
+                            this.requestRender();
                         } else {
                             console.warn(`Unable to get group setting for ${this.groupName}`)
                         }
@@ -196,10 +197,11 @@ export abstract class ViewContainer extends GroupFolder {
                     .setTitle(`${groupSetting?.logsFolderVisible ? "Hide" : "Show"} logs`)
                     .setIcon(groupSetting?.logsFolderVisible ? "eye-off" : "eye")
                     .setSection("hide")
-                    .onClick(() => {
+                    .onClick(async () => {
                         if (groupSetting) {
                             groupSetting.logsFolderVisible = !groupSetting.logsFolderVisible;
-                            this.saveSettingsCallback();
+                            await this.saveSettingsCallback();
+                            this.requestRender();
                         } else {
                             console.warn(`Unable to get group setting for ${this.groupName}`)
                         }
@@ -211,10 +213,11 @@ export abstract class ViewContainer extends GroupFolder {
                         .setTitle(`Include ${folderPath}`)
                         .setIcon("folder-plus")
                         .setSection("include")
-                        .onClick(() => {
+                        .onClick(async () => {
                             if (groupSetting) {
                                 groupSetting.excludedFolders.remove(folderPath);
-                                this.saveSettingsCallback();
+                                await this.saveSettingsCallback();
+                                this.requestRender();
                             } else {
                                 console.warn(`Unable to get group setting for ${this.groupName}`)
                             }

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -105,7 +105,7 @@ export abstract class ViewContainer extends GroupFolder {
     }
 
     protected getGroupSetting() {
-        // todo: this is a little dangerous because someone could have a tag that
+        // todo(#64): this is a little dangerous because someone could have a tag that
         //  conflicts with an rx group name and this would return the wrong thing
         return (
             (this.settings.rxGroups.find(group => group.groupName === this.groupName)) ??

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -2,6 +2,7 @@ import { App, FrontMatterCache, Menu, setIcon, TFile } from "obsidian";
 import {FileClickCallback, GroupFolder, FileAddedCallback} from "./group_folder";
 import { ObloggerSettings, RxGroupSettings } from "./settings";
 import { buildStateFromFile, FileState } from "./constants";
+import { FolderSuggestModal } from "./folder_suggest_modal";
 
 interface RenderedFileCache {
     file: TFile;
@@ -226,7 +227,17 @@ export abstract class ViewContainer extends GroupFolder {
                     .setIcon("folder-x")
                     .setSection("exclude")
                     .onClick(() => {
-                        console.log("todo: show folder selection")
+                        new FolderSuggestModal(
+                            this.app,
+                            ["/"].concat(groupSetting?.excludedFolders ?? []),
+                            async (selectedPath: string) => {
+                                if (!groupSetting?.excludedFolders.contains(selectedPath)) {
+                                    groupSetting?.excludedFolders.push(selectedPath);
+                                    await this.saveSettingsCallback();
+                                    this.requestRender();
+                                }
+                            }
+                        ).open();
                     });
             });
         });

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -104,6 +104,8 @@ export abstract class ViewContainer extends GroupFolder {
     }
 
     protected getGroupSetting() {
+        // todo: this is a little dangerous because someone could have a tag that
+        //  conflicts with an rx group name and this would return the wrong thing
         return (
             (this.settings.rxGroups.find(group => group.groupName === this.groupName)) ??
             (this.settings.tagGroups.find(group => group.tag === this.groupName))

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -165,6 +165,8 @@ export abstract class ViewContainer extends GroupFolder {
             );
         }
 
+        const groupSetting = this.getGroupSetting();
+
         menu.addItem(item => {
             item
                 .setTitle("Folder exclusions")
@@ -176,27 +178,32 @@ export abstract class ViewContainer extends GroupFolder {
             const subMenu = item.setSubmenu() as Menu;
             subMenu.addItem(subItem => {
                 subItem
-                    .setTitle("Hide templates")
-                    .setIcon("eye-off")
+                    .setTitle(`${groupSetting?.templatesFolderVisible ? "Hide" : "Show"} templates`)
+                    .setIcon(groupSetting?.templatesFolderVisible ? "eye-off" : "eye")
                     .setSection("hide");
             });
             subMenu.addItem(subItem => {
                 subItem
-                    .setTitle("Show logs")
-                    .setIcon("eye")
+                    .setTitle(`${groupSetting?.logsFolderVisible ? "Hide" : "Show"} logs`)
+                    .setIcon(groupSetting?.logsFolderVisible ? "eye-off" : "eye")
                     .setSection("hide");
             });
-            subMenu.addItem(subItem => {
-                subItem
-                    .setTitle("Include asdf")
-                    .setIcon("folder-plus")
-                    .setSection("include");
+            groupSetting?.excludedFolders.forEach(folderPath => {
+                subMenu.addItem(subItem => {
+                    subItem
+                        .setTitle(`Include ${folderPath}`)
+                        .setIcon("folder-plus")
+                        .setSection("include");
+                });
             });
             subMenu.addItem(subItem => {
                 subItem
                     .setTitle("Exclude folder")
                     .setIcon("folder-x")
-                    .setSection("exclude");
+                    .setSection("exclude")
+                    .onClick(() => {
+                        console.log("todo: show folder selection")
+                    });
             });
         });
 

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -19,7 +19,7 @@ export abstract class ViewContainer extends GroupFolder {
     fileClickCallback: FileClickCallback;
     fileAddedCallback: FileAddedCallback;
     requestRenderCallback: () => void;
-    saveSettingsCallback: () => void;
+    saveSettingsCallback: () => Promise<void>;
     hideCallback: () => void;
     moveCallback: (up: boolean) => void;
     pinCallback: ((pin: boolean) => void) | undefined;
@@ -52,7 +52,7 @@ export abstract class ViewContainer extends GroupFolder {
         showStatusIcon: boolean,
         requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => void,
+        saveSettingsCallback: () => Promise<void>,
         getGroupIconCallback: (isCollapsed: boolean) => string,
         moveCallback: (up: boolean) => void,
         hideCallback: () => void,


### PR DESCRIPTION
fixes #47 
some work might intersect with #64 

- labels `saveSettingsCallback()` more correctly as returning a `Promise<void>`
- adds a helper function for getting all templates folders (from templater and core plugin)
- splits `OtcGroupSettings` and `RxGroupSettings` into versioned object (but without actual version numbers since the version numbers are tied implicitly to the settings version number)
- adds new versions of `[Otc|Rx]GroupSettings` which holds the new per-group folder exclusion settings
- deprecates `ObloggerSettings_v0.excludedFolder` property in favor of new per-group exclusions
- bumps `ObloggerSettings` to version 3, re-typing `rxGroups` and `tagGroups` to the new `[Otc|Rx]GroupSettings`
- leverages the new per-group exclusions when rendering groups
- adds todo warning of possible bug in `getGroupSetting`
- adds exclusion settings to group context menus