### PR TITLE
#55: open in new leaf when ctrl/cmd is down

### DIFF
--- a/src/group_folder.ts
+++ b/src/group_folder.ts
@@ -10,7 +10,7 @@ import { isBookmarked } from "./constants";
 
 const COLLAPSED_CLASS_IDENTIFIER = "collapsed";
 
-export type FileClickCallback = (file: TFile) => void;
+export type FileClickCallback = (file: TFile, isCtrlCmdKeyDown: boolean) => void;
 export type FileAddedCallback = (
     file: TFile,
     contentItem: HTMLElement) => void;
@@ -237,7 +237,9 @@ Created at ${window.moment(file.stat.ctime).format("YYYY-MM-DD HH:mm")}`;
         root_childItem.addClass("child-item");
         root_childItem.style.marginLeft = `-${12+17*recursionDepth}px`
         root_childItem.style.paddingLeft = `${16+17*recursionDepth}px`
-        root_childItem.addEventListener("click", () => fileClickCallback(file));
+        root_childItem.addEventListener("click", (e) => {
+            fileClickCallback(file, e.metaKey || e.ctrlKey);
+        });
 
         const statusIconDiv = document.createElement("div");
         statusIconDiv.addClass("status-icon");

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -11,7 +11,7 @@ import {
 import { ObloggerSettings, RxGroupType, OtcGroupSettings as SettingsTagGroup } from "./settings";
 import { TagGroupContainer } from "./tag_group_container";
 import { DailiesContainer } from "./dailies_container";
-import { GroupFolder } from "./group_folder";
+import { FileClickCallback, GroupFolder } from "./group_folder";
 import { RecentsContainer } from "./recents_container";
 import { UntaggedContainer } from "./untagged_container";
 import { FilesContainer } from "./files_container";
@@ -55,7 +55,7 @@ export class ObloggerView extends ItemView {
     rxGroupsDiv: HTMLElement | undefined;
     showLoggerCallbackFn: () => Promise<void>;
     saveSettingsCallback: () => Promise<void>;
-    fileClickCallback: (file: TFile) => void;
+    fileClickCallback: FileClickCallback;
     fileAddedCallback: (
         file: TFile,
         contentItem: HTMLElement) => void;
@@ -126,9 +126,8 @@ export class ObloggerView extends ItemView {
             })
         );
 
-        this.fileClickCallback = (file: TFile) => {
-            const { workspace } = this.app;
-            return workspace.getLeaf(false).openFile(file);
+        this.fileClickCallback = (file: TFile, isCtrlCmdKeyDown: boolean) => {
+            return this.app.workspace.getLeaf(isCtrlCmdKeyDown).openFile(file);
         }
 
         this.fileAddedCallback = (


### PR DESCRIPTION
fixes #55 

(ignore the branch name, I typo'd it)

- adds second parameter to `FileClickCallback` which specifies if a ctrl/cmd key is down
- sets that parameter when either the `meta` key (windows key or cmd key) is down and falls back to `ctrl`. This works fine on mac because apparently the OS handles `ctrl-click` so it doesn't even make it to the app.
- passes that parameter directly into the option to open the file in a new leaf in the handler