### PR TITLE
#28: be more careful with null values during logging

### DIFF
--- a/src/logger_modal.ts
+++ b/src/logger_modal.ts
@@ -302,7 +302,6 @@ export class LoggerModal extends Modal {
                     return;
                 }
                 
-                console.log(`adding ${value}`)
                 acc.set(fmKey, (acc.get(fmKey) ?? new Set()).add(value));
             })
             return acc;

--- a/src/logger_modal.ts
+++ b/src/logger_modal.ts
@@ -294,10 +294,16 @@ export class LoggerModal extends Modal {
                 if (EXCLUDED_FIELDS.has(fmKey)) {
                     return;
                 }
-                const value = String(fm[fmKey]).trim();
-                if (value) {
-                    acc.set(fmKey, (acc.get(fmKey) ?? new Set()).add(value));
+                if (!fm[fmKey]) {
+                    return;
                 }
+                const value = String(fm[fmKey]).trim();
+                if (!value) {
+                    return;
+                }
+                
+                console.log(`adding ${value}`)
+                acc.set(fmKey, (acc.get(fmKey) ?? new Set()).add(value));
             })
             return acc;
         }, new Map<string, Set<string>>());


### PR DESCRIPTION
fixes #28 

when we are loading up the possible values for a metadata field, we were casting the value to string, trimming it, then seeing if it was valid.

if the value was empty, then `fm[fmKey]` returns `null` which we were then stringifying into `"null"` which passed the `if (value)` check and added "null" to the list of values.

the fix is to explicitly check `fm[fmKey]` first, then stringify (and check) then add the value.