### PR TITLE
#101: refactor folder exclusions

### DIFF
--- a/src/dailies_container.ts
+++ b/src/dailies_container.ts
@@ -128,7 +128,7 @@ export class DailiesContainer extends ViewContainer {
     }
 
     private shouldIncludeFile(file: TFile, excludedFolders: string[]): boolean {
-        if (file.parent && excludedFolders.contains(file.parent.path)) {
+        if (this.isFileExcluded(file, excludedFolders)) {
             return false;
         }
 

--- a/src/files_container.ts
+++ b/src/files_container.ts
@@ -260,12 +260,8 @@ export class FilesContainer extends ViewContainer {
 
     protected buildFileStructure(excludedFolders: string[]): void {
         const includedFiles = this.app.vault.getFiles().filter(file => {
-            if (
-                file.parent &&
-                excludedFolders.some(
-                    excludedFolder =>
-                        file.parent?.path.startsWith(excludedFolder))
-            ) {
+
+            if (this.isFileExcluded(file, excludedFolders)) {
                 return false;
             }
 

--- a/src/recents_container.ts
+++ b/src/recents_container.ts
@@ -135,35 +135,8 @@ export class RecentsContainer extends ViewContainer {
                 if (foundFilesCount >= this.recentsCount) {
                     return;
                 }
-                if (file.parent) {
-                    let excluded = false;
-                    file.parent.path.split("/").reduce(
-                        (previousValue, currentValue) => {
-                            // early bail out if we've already determined it's excluded
-                            if (excluded) {
-                                return "";
-                            }
-
-                            // build the new value, concatenating the next path part
-                            const newValue =
-                                previousValue.length === 0 ?
-                                currentValue :
-                                (previousValue + "/" + currentValue);
-
-                            // check if it's excluded
-                            if (excludedFolders.contains(newValue)) {
-                                excluded = true;
-                                return "";
-                            }
-
-                            // not excluded, keep building
-                            return newValue;
-                        }, "");
-
-                    // check exclusion status
-                    if (excluded) {
-                        return;
-                    }
+                if (this.isFileExcluded(file, excludedFolders)) {
+                    return;
                 }
                 this.addFileToFolder(
                     file,

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -223,7 +223,7 @@ export class TagGroupContainer extends ViewContainer {
         isolatedGroupName: string | undefined
     ): FileTags | null {
         // filter out excluded
-        if (file.parent && excludedFolders.contains(file.parent.path)) {
+        if (this.isFileExcluded(file, excludedFolders)) {
             return null;
         }
         const cache = this.app.metadataCache.getFileCache(file);

--- a/src/untagged_container.ts
+++ b/src/untagged_container.ts
@@ -261,12 +261,7 @@ export class UntaggedContainer extends ViewContainer {
                 return false;
             }
 
-            if (
-                file.parent &&
-                excludedFolders.some(
-                    (excludedFolder: string) =>
-                        file.parent?.path.startsWith(excludedFolder))
-            ) {
+            if (this.isFileExcluded(file, excludedFolders)) {
                 return false;
             }
 


### PR DESCRIPTION
fixes #101 
fixes #77 

- moves building the excluded folders to inside of the `ViewContainer`
- adds a `isFileExcluded()` function that all container types can use
  - changes folder exclusion to check to check each successive path part of a file's parent instead of just the parent itself. this is important, because if you exclude "logs", but a file is saved in "logs/gardening" then because `"logs" != "logs/gardening"`, then it will think it should include it. With the new implementation, we check "logs" and "logs/gardening" against the exclusion list.
- uses the `isFileExcluded()` check in all containers
- fixes a bug in recents where we were limiting the count before filtering
- removes rendering debug console logs