### PR TITLE
#64: combine rx and otc group settings

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -215,7 +215,7 @@ export const upgradeSettings = (currentVersion: number, settings: ObloggerSettin
 
 export const CURRENT_VERSION = 4;
 
-export const DEFAULT_SETTINGS: ObloggerSettings = {
+export const DEFAULT_SETTINGS: ObloggerSettings_v3 = {
     version: 3,
     avatarVisible: true,
     vaultVisible: true,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -47,6 +47,9 @@ interface RxGroupSettings_v1 extends RxGroupSettings_v0 {
     logsFolderVisible: boolean;
 }
 
+/**
+ * @deprecated Use {@link GroupSettings} instead
+ */
 export type RxGroupSettings = RxGroupSettings_v1;
 
 interface OtcGroupSettings_v0 {
@@ -63,6 +66,9 @@ interface OtcGroupSettings_v1 extends OtcGroupSettings_v0 {
     logsFolderVisible: boolean;
 }
 
+/**
+ * @deprecated Use {@link GroupSettings} instead
+ */
 export type OtcGroupSettings = OtcGroupSettings_v1;
 
 export interface GroupSettings {
@@ -111,6 +117,9 @@ interface ObloggerSettings_v2 extends ObloggerSettings_v1 {
 }
 
 interface ObloggerSettings_v3 extends ObloggerSettings_v2 {
+    /**
+     * @deprecated Use {@link ObloggerSettings_v4.otcGroups} instead
+     */
     tagGroups: OtcGroupSettings_v1[];
     rxGroups: RxGroupSettings_v1[];
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -32,7 +32,6 @@ export const RxGroupType = {
     DAILIES: "dailies"
 }
 
-// TODO(#64): combine this with OtcGroupSettings
 interface RxGroupSettings_v0 {
     groupName: string;
     collapsedFolders: string[];
@@ -165,6 +164,8 @@ const UPGRADE_FUNCTIONS: {[id: number]: (settings: ObloggerSettings) => void } =
 
                 group.excludedFolders = [];
             });
+            // This is deprecated in a later version. It's okay that we're using
+            // it here because it will be upgraded shortly...
             newSettings.tagGroups.forEach(group => {
                 group.logsFolderVisible = false;
                 group.templatesFolderVisible = false;
@@ -223,6 +224,7 @@ export const DEFAULT_SETTINGS: ObloggerSettings = {
     otcSeparatorVisible: true,
     recentsCount: 10,
     postLogAction: PostLogAction.QUIETLY,
+    // this is deprecated, but it's expected here in v3, it'll be removed in v4
     tagGroups: [],
     loggingPath: "",
     avatarPath: "",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,21 +1,5 @@
 import { TFile } from "obsidian";
 
-interface OtcGroupSettings_v0 {
-    tag: string;
-    collapsedFolders: string[];
-    isPinned: boolean;
-    sortMethod?: string;
-    sortAscending?: boolean;
-}
-
-interface OtcGroupSettings_v1 extends OtcGroupSettings_v0 {
-    excludedFolders: string[];
-    templatesFolderVisible: boolean;
-    logsFolderVisible: boolean;
-}
-
-export type OtcGroupSettings = OtcGroupSettings_v1;
-
 export const ContainerSortMethod = {
     ALPHABETICAL: "alphabetical",
     CTIME: "ctime",
@@ -64,6 +48,22 @@ interface RxGroupSettings_v1 extends RxGroupSettings_v0 {
 }
 
 export type RxGroupSettings = RxGroupSettings_v1;
+
+interface OtcGroupSettings_v0 {
+    tag: string;
+    collapsedFolders: string[];
+    isPinned: boolean;
+    sortMethod?: string;
+    sortAscending?: boolean;
+}
+
+interface OtcGroupSettings_v1 extends OtcGroupSettings_v0 {
+    excludedFolders: string[];
+    templatesFolderVisible: boolean;
+    logsFolderVisible: boolean;
+}
+
+export type OtcGroupSettings = OtcGroupSettings_v1;
 
 export const PostLogAction = {
     QUIETLY: "quietly",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -65,6 +65,18 @@ interface OtcGroupSettings_v1 extends OtcGroupSettings_v0 {
 
 export type OtcGroupSettings = OtcGroupSettings_v1;
 
+export interface GroupSettings {
+    groupName: string;
+    collapsedFolders: string[];
+    isPinned: boolean;
+    isVisible: boolean;
+    sortMethod: string;
+    sortAscending: boolean;
+    excludedFolders: string[];
+    templatesFolderVisible: boolean;
+    logsFolderVisible: boolean;
+}
+
 export const PostLogAction = {
     QUIETLY: "quietly",
     OPEN: "open",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -185,14 +185,14 @@ const UPGRADE_FUNCTIONS: {[id: number]: (settings: ObloggerSettings) => void } =
             newSettings.otcGroups = newSettings.tagGroups.map(tagGroup => {
                 return {
                     groupName: tagGroup.tag,
-                    collapsedFolders: tagGroup.collapsedFolders,
-                    isPinned: tagGroup.isPinned,
+                    collapsedFolders: tagGroup.collapsedFolders ?? [],
+                    isPinned: tagGroup.isPinned ?? false,
                     isVisible: true,
                     sortMethod: tagGroup.sortMethod ?? ContainerSortMethod.ALPHABETICAL,
                     sortAscending: tagGroup.sortAscending ?? true,
-                    excludedFolders: tagGroup.excludedFolders,
-                    templatesFolderVisible: tagGroup.templatesFolderVisible,
-                    logsFolderVisible: tagGroup.logsFolderVisible
+                    excludedFolders: tagGroup.excludedFolders ?? [],
+                    templatesFolderVisible: tagGroup.templatesFolderVisible ?? false,
+                    logsFolderVisible: tagGroup.logsFolderVisible ?? false
                 }
             });
             // Clear the now deprecated option

--- a/src/tag_group_container.ts
+++ b/src/tag_group_container.ts
@@ -1,7 +1,7 @@
 import { App, getAllTags, Menu, MenuItem, TFile } from "obsidian";
 import { FileClickCallback, FileAddedCallback } from "./group_folder";
 import { ViewContainer } from "./view_container";
-import { ContainerSortMethod, getSortMethodDisplayText, ObloggerSettings } from "./settings";
+import { ContainerSortMethod, getSortMethodDisplayText, GroupSettings, ObloggerSettings } from "./settings";
 import { FileState } from "./constants";
 
 
@@ -48,6 +48,11 @@ export class TagGroupContainer extends ViewContainer {
             pinCallback,
             isPinned
         );
+    }
+
+    protected getGroupSetting(): GroupSettings | undefined {
+        // override to search otcGroups instead of rxGroups
+        return this.settings.otcGroups.find(group => group.groupName === this.groupName);
     }
 
     protected wouldBeRendered(state: FileState): boolean {

--- a/src/view_container.ts
+++ b/src/view_container.ts
@@ -1,6 +1,6 @@
 import { App, FrontMatterCache, Menu, setIcon, TFile } from "obsidian";
 import {FileClickCallback, GroupFolder, FileAddedCallback} from "./group_folder";
-import { ObloggerSettings, OtcGroupSettings, RxGroupSettings } from "./settings";
+import { GroupSettings, ObloggerSettings, OtcGroupSettings, RxGroupSettings } from "./settings";
 import { buildStateFromFile, FileState } from "./constants";
 import { FolderSuggestModal } from "./folder_suggest_modal";
 
@@ -101,16 +101,13 @@ export abstract class ViewContainer extends GroupFolder {
     }
 
     protected isVisible(): boolean {
-        return (this.getGroupSetting() as RxGroupSettings)?.isVisible ?? true;
+        return this.getGroupSetting()?.isVisible ?? true;
     }
 
-    protected getGroupSetting() {
-        // todo(#64): this is a little dangerous because someone could have a tag that
-        //  conflicts with an rx group name and this would return the wrong thing
-        return (
-            (this.settings.rxGroups.find(group => group.groupName === this.groupName)) ??
-            (this.settings.tagGroups.find(group => group.tag === this.groupName))
-        );
+    protected getGroupSetting(): GroupSettings | undefined {
+        // default to fetching from rx groups. override in TagGroupContainer
+        // to fetch from otc groups.
+        return this.settings.rxGroups.find(group => group.groupName === this.groupName);
     }
 
     protected requestRender() {


### PR DESCRIPTION
fixes #64 

- combines `RxGroupSettings` and `OtcGroupSettings` into a single `GroupSettings` interface
  - changed `OtcGroupSettings.tag` to be `GroupSettings.groupName`
  - field `isVisible` defaults to `true` for OTC groups since they're always visible
  - field `isPinned` defaults to `false` for RX groups since they can't be pinned
- Added new `ObloggerSettings_v4` which...
  - upgrades `rxGroups` to type `GroupSettings[]`
  - deprecates `tagGroups`
  - adds new `otcGroups` which transfers data from `tagGroups` during upgrade
- addresses new properties/types throughout codebase
- pins the `DEFAULT_SETTINGS` object to `ObloggerSettings_v3` so we stop needing to change it every time we change settings