### PR TITLE
#112: extract callbacks into object

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "dev": "npx rollup --config rollup-debug.config.js -w",
         "build": "npx rollup --config rollup.config.js --environment BUILD:production",
         "version": "node scripts/version-bump.mjs && git add manifest.json versions.json",
-        "lint": "npx eslint src/*.ts"
+        "lint": "npx eslint src --ext .ts"
     },
     "keywords": [
         "obsidian",

--- a/src/containers/container_callbacks.ts
+++ b/src/containers/container_callbacks.ts
@@ -1,0 +1,13 @@
+import { FileAddedCallback, FileClickCallback } from "./group_folder";
+
+export interface ContainerCallbacks {
+    fileClickCallback: FileClickCallback;
+    fileAddedCallback: FileAddedCallback;
+    collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void;
+    requestRenderCallback: () => void;
+    saveSettingsCallback: () => Promise<void>;
+    getGroupIconCallback: (isCollapsed: boolean) => string,
+    hideCallback: () => void;
+    moveCallback: (up: boolean) => void;
+    pinCallback: ((pin: boolean) => void) | undefined;
+}

--- a/src/containers/otc/tag_group_container.ts
+++ b/src/containers/otc/tag_group_container.ts
@@ -1,8 +1,8 @@
 import { App, getAllTags, Menu, MenuItem, TFile } from "obsidian";
-import { FileClickCallback, FileAddedCallback } from "../group_folder";
 import { ViewContainer } from "../view_container";
 import { ContainerSortMethod, getSortMethodDisplayText, GroupSettings, ObloggerSettings } from "../../settings";
 import { FileState } from "../../constants";
+import { ContainerCallbacks } from "../container_callbacks";
 
 
 type TagFileMap = { [key: string]: TFile[] };
@@ -18,35 +18,20 @@ export class TagGroupContainer extends ViewContainer {
     constructor(
         app: App,
         baseTag: string,
-        removeCallback: () => void,
-        moveCallback: (up: boolean) => void,
-        fileClickCallback: FileClickCallback,
-        fileAddedCallback: FileAddedCallback,
-        collapseChangedCallback: (baseTag: string, collapsedFolders: string[], save: boolean) => void,
-        requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => Promise<void>,
-        pinCallback: (pin: boolean) => void,
-        isPinned: boolean
+        isPinned: boolean,
+        callbacks: ContainerCallbacks
     ) {
         super(
             app,
             baseTag,
-            fileClickCallback,
-            fileAddedCallback,
-            collapseChangedCallback,
             false,
-            requestRenderCallback,
             settings,
-            saveSettingsCallback,
-            (isCollapsed) => isCollapsed ? "folder-closed" : "folder-open",
-            moveCallback,
-            removeCallback,
             false, // isMovable
             true, // canCollapseInnerFolders
             true, // canBePinned
-            pinCallback,
-            isPinned
+            isPinned,
+            callbacks
         );
     }
 
@@ -184,7 +169,7 @@ export class TagGroupContainer extends ViewContainer {
                     groupSetting.sortMethod = method;
                     groupSetting.sortAscending = true;
                 }
-                await this.saveSettingsCallback();
+                await this.callbacks.saveSettingsCallback();
                 this.requestRender();
             }
 

--- a/src/containers/rx/dailies_container.ts
+++ b/src/containers/rx/dailies_container.ts
@@ -1,42 +1,28 @@
 import { App, FrontMatterCache, getAllTags, Menu, moment, Notice, TFile } from "obsidian";
-import { FileClickCallback, FileAddedCallback } from "../group_folder";
 import { ViewContainer } from "../view_container";
 import { ObloggerSettings, RxGroupType } from "../../settings";
 import { NewTagModal } from "../../new_tag_modal";
 import { FileState } from "../../constants";
+import { ContainerCallbacks } from "../container_callbacks";
 
 export class DailiesContainer extends ViewContainer {
     fileEntryDates: { file: TFile, date: string }[]
 
     constructor(
         app: App,
-        fileClickCallback: FileClickCallback,
-        fileAddedCallback: FileAddedCallback,
-        collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
-        requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => Promise<void>,
-        moveCallback: (up: boolean) => void,
-        hideCallback: () => void
+        callbacks: ContainerCallbacks
     ) {
         super(
             app,
             RxGroupType.DAILIES,
-            fileClickCallback,
-            fileAddedCallback,
-            collapseChangedCallback,
             false, // showStatusIcon
-            requestRenderCallback,
             settings,
-            saveSettingsCallback,
-            (isCollapsed) => isCollapsed ? "folder-closed" : "folder-open",
-            moveCallback,
-            hideCallback,
             true, // isMovable
             true, // canCollapseInnerFolders
             false, // canBePinned
-            undefined,
-            false); // isPinned
+            false, // isPinned
+            callbacks);
 
         this.fileEntryDates = [];
     }
@@ -113,7 +99,7 @@ export class DailiesContainer extends ViewContainer {
                             return;
                         }
                         this.settings.dailiesTag = result;
-                        this.saveSettingsCallback();
+                        await this.callbacks.saveSettingsCallback();
                         this.requestRender();
                     });
                     modal.open();

--- a/src/containers/rx/dailies_container.ts
+++ b/src/containers/rx/dailies_container.ts
@@ -1,11 +1,11 @@
 import { App, FrontMatterCache, getAllTags, Menu, moment, Notice, TFile } from "obsidian";
-import { ViewContainer } from "../view_container";
 import { ObloggerSettings, RxGroupType } from "../../settings";
 import { NewTagModal } from "../../new_tag_modal";
 import { FileState } from "../../constants";
 import { ContainerCallbacks } from "../container_callbacks";
+import { RxContainer } from "./rx_container";
 
-export class DailiesContainer extends ViewContainer {
+export class DailiesContainer extends RxContainer {
     fileEntryDates: { file: TFile, date: string }[]
 
     constructor(
@@ -15,14 +15,12 @@ export class DailiesContainer extends ViewContainer {
     ) {
         super(
             app,
-            RxGroupType.DAILIES,
-            false, // showStatusIcon
             settings,
-            true, // isMovable
-            true, // canCollapseInnerFolders
-            false, // canBePinned
-            false, // isPinned
-            callbacks);
+            callbacks,
+            RxGroupType.DAILIES,
+            false, // showStatusIcon,
+            true // canCollapseInnerFolders
+        );
 
         this.fileEntryDates = [];
     }
@@ -50,28 +48,8 @@ export class DailiesContainer extends ViewContainer {
         return `No documents tagged #${this.settings.dailiesTag};`
     }
 
-    protected getHideText(): string {
-        return "Hide";
-    }
-
-    protected getHideIcon(): string {
-        return "eye-off"
-    }
-
     protected getTitleText(): string {
         return "Daily Notes";
-    }
-
-    protected getTitleTooltip(): string {
-        return "";
-    }
-
-    protected getTextIcon(): string {
-        return "";
-    }
-
-    protected getTextIconTooltip(): string {
-        return "";
     }
 
     protected getPillText(): string {
@@ -107,10 +85,6 @@ export class DailiesContainer extends ViewContainer {
             });
             menu.showAtMouseEvent(e);
         }
-    }
-
-    protected getContainerClass(): string {
-        return "rx-child";
     }
 
     private shouldIncludeFile(file: TFile, excludedFolders: string[]): boolean {

--- a/src/containers/rx/files_container.ts
+++ b/src/containers/rx/files_container.ts
@@ -1,39 +1,28 @@
 import { ViewContainer } from "../view_container";
-import { FileAddedCallback, FileClickCallback } from "../group_folder";
 import { ObloggerSettings, ContainerSortMethod, getSortMethodDisplayText, RxGroupType, getFileType } from "../../settings";
 import { App, Menu, MenuItem, moment, TFile } from "obsidian";
 import { FileState } from "../../constants";
+import { ContainerCallbacks } from "../container_callbacks";
 
 export class FilesContainer extends ViewContainer {
     constructor(
         app: App,
-        fileClickCallback: FileClickCallback,
-        fileAddedCallback: FileAddedCallback,
-        collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
-        requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => Promise<void>,
-        moveCallback: (up: boolean) => void,
-        hideCallback: () => void
+        callbacks: ContainerCallbacks
     ) {
+        // Override the default behavior with special packaging
+        callbacks.getGroupIconCallback = (isCollapsed) => isCollapsed ? "package" : "package-open";
+
         super(
             app,
             RxGroupType.FILES,
-            fileClickCallback,
-            fileAddedCallback,
-            collapseChangedCallback,
             false,
-            requestRenderCallback,
             settings,
-            saveSettingsCallback,
-            (isCollapsed) => isCollapsed ? "package" : "package-open",
-            moveCallback,
-            hideCallback,
             true, // isMovable
             true, // canCollapseInnerFolders
             false, // canBePinned
-            undefined,
-            false); // isPinned
+            false, // isPinned
+            callbacks);
     }
 
     protected wouldBeRendered(state: FileState): boolean {
@@ -108,7 +97,7 @@ export class FilesContainer extends ViewContainer {
                     groupSetting.sortMethod = method;
                     groupSetting.sortAscending = true;
                 }
-                await this.saveSettingsCallback();
+                await this.callbacks.saveSettingsCallback();
                 this.requestRender();
             }
 

--- a/src/containers/rx/files_container.ts
+++ b/src/containers/rx/files_container.ts
@@ -1,10 +1,10 @@
-import { ViewContainer } from "../view_container";
 import { ObloggerSettings, ContainerSortMethod, getSortMethodDisplayText, RxGroupType, getFileType } from "../../settings";
 import { App, Menu, MenuItem, moment, TFile } from "obsidian";
 import { FileState } from "../../constants";
 import { ContainerCallbacks } from "../container_callbacks";
+import { RxContainer } from "./rx_container";
 
-export class FilesContainer extends ViewContainer {
+export class FilesContainer extends RxContainer {
     constructor(
         app: App,
         settings: ObloggerSettings,
@@ -15,14 +15,12 @@ export class FilesContainer extends ViewContainer {
 
         super(
             app,
-            RxGroupType.FILES,
-            false,
             settings,
-            true, // isMovable
-            true, // canCollapseInnerFolders
-            false, // canBePinned
-            false, // isPinned
-            callbacks);
+            callbacks,
+            RxGroupType.FILES,
+            false, // showStatusIcon,
+            true // canCollapseInnerFolders
+        );
     }
 
     protected wouldBeRendered(state: FileState): boolean {
@@ -63,18 +61,6 @@ export class FilesContainer extends ViewContainer {
 
     protected getTitleText(): string {
         return "Files";
-    }
-
-    protected getTitleTooltip(): string {
-        return "";
-    }
-
-    protected getTextIcon(): string {
-        return "";
-    }
-
-    protected getTextIconTooltip(): string {
-        return "";
     }
 
     protected getPillText(): string {
@@ -135,18 +121,6 @@ export class FilesContainer extends ViewContainer {
 
             menu.showAtMouseEvent(e);
         }
-    }
-
-    protected getContainerClass(): string {
-        return "rx-child";
-    }
-
-    protected getHideText(): string {
-        return "Hide";
-    }
-
-    protected getHideIcon(): string {
-        return "eye-off"
     }
 
     private buildAlphabeticalFileStructure(

--- a/src/containers/rx/recents_container.ts
+++ b/src/containers/rx/recents_container.ts
@@ -1,8 +1,8 @@
-import {FileClickCallback, FileAddedCallback } from "../group_folder";
 import { ViewContainer } from "../view_container";
 import { App, Menu } from "obsidian";
 import { ObloggerSettings, RxGroupType } from "../../settings";
 import { FileState } from "../../constants";
+import { ContainerCallbacks } from "../container_callbacks";
 
 const RECENT_COUNT_OPTIONS = [5, 10, 15];
 
@@ -11,33 +11,19 @@ export class RecentsContainer extends ViewContainer {
 
     constructor(
         app: App,
-        fileClickCallback: FileClickCallback,
-        fileAddedCallback: FileAddedCallback,
-        collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
-        requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => Promise<void>,
-        moveCallback: (up: boolean) => void,
-        hideCallback: () => void
+        callbacks: ContainerCallbacks
     ) {
         super(
             app,
             RxGroupType.RECENTS,
-            fileClickCallback,
-            fileAddedCallback,
-            collapseChangedCallback,
             true,
-            requestRenderCallback,
             settings,
-            saveSettingsCallback,
-            (isCollapsed) => isCollapsed ? "folder-closed" : "folder-open",
-            moveCallback,
-            hideCallback,
             true, // isMovable
             false, // canCollapseInnerFolders
             false, // canBePinned
-            undefined,
-            false); // isPinned
+            false, // isPinned
+            callbacks);
 
         this.recentsCount = settings.recentsCount;
     }
@@ -104,7 +90,7 @@ export class RecentsContainer extends ViewContainer {
                         this.recentsCount = amount;
                         this.requestRender();
                         this.settings.recentsCount = amount;
-                        this.saveSettingsCallback();
+                        return this.callbacks.saveSettingsCallback();
                     });
                     item.setIcon(this.recentsCount === amount ? "check" : "");
                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/containers/rx/recents_container.ts
+++ b/src/containers/rx/recents_container.ts
@@ -1,12 +1,12 @@
-import { ViewContainer } from "../view_container";
 import { App, Menu } from "obsidian";
 import { ObloggerSettings, RxGroupType } from "../../settings";
 import { FileState } from "../../constants";
 import { ContainerCallbacks } from "../container_callbacks";
+import { RxContainer } from "./rx_container";
 
 const RECENT_COUNT_OPTIONS = [5, 10, 15];
 
-export class RecentsContainer extends ViewContainer {
+export class RecentsContainer extends RxContainer {
     recentsCount = 10;
 
     constructor(
@@ -16,14 +16,12 @@ export class RecentsContainer extends ViewContainer {
     ) {
         super(
             app,
-            RxGroupType.RECENTS,
-            true,
             settings,
-            true, // isMovable
-            false, // canCollapseInnerFolders
-            false, // canBePinned
-            false, // isPinned
-            callbacks);
+            callbacks,
+            RxGroupType.RECENTS,
+            true, // showStatusIcon,
+            false // canCollapseInnerFolders
+        );
 
         this.recentsCount = settings.recentsCount;
     }
@@ -44,28 +42,8 @@ export class RecentsContainer extends ViewContainer {
         return "No recents";
     }
 
-    protected getHideText(): string {
-        return "Hide";
-    }
-
-    protected getHideIcon(): string {
-        return "eye-off"
-    }
-
     protected getTitleText(): string {
         return "Recents";
-    }
-
-    protected getTitleTooltip(): string {
-        return "";
-    }
-
-    protected getTextIcon(): string {
-        return "";
-    }
-
-    protected getTextIconTooltip(): string {
-        return "";
     }
 
     protected getPillText(): string {
@@ -104,10 +82,6 @@ export class RecentsContainer extends ViewContainer {
             // @ts-ignore
             menu.dom.addClass("oblogger-pill-menu");
         }
-    }
-
-    protected getContainerClass(): string {
-        return "rx-child";
     }
 
     protected buildFileStructure(excludedFolders: string[]): void {

--- a/src/containers/rx/rx_container.ts
+++ b/src/containers/rx/rx_container.ts
@@ -1,0 +1,51 @@
+import { ViewContainer } from "../view_container";
+import { ObloggerSettings } from "../../settings";
+import { ContainerCallbacks } from "../container_callbacks";
+import { App } from "obsidian";
+
+export abstract class RxContainer extends ViewContainer {
+    protected constructor(
+        app: App,
+        settings: ObloggerSettings,
+        callbacks: ContainerCallbacks,
+        groupType: string,
+        showStatusIcon: boolean,
+        canCollapseInnerFolders: boolean
+    ) {
+        super(
+            app,
+            groupType, // viewName
+            showStatusIcon,
+            settings,
+            true, // isMovable
+            canCollapseInnerFolders,
+            false, // canBePinned
+            false, // isPinned
+            callbacks
+        )
+    }
+
+    protected getHideText(): string {
+        return "Hide";
+    }
+
+    protected getHideIcon(): string {
+        return "eye-off"
+    }
+
+    protected getTitleTooltip(): string {
+        return "";
+    }
+
+    protected getTextIcon(): string {
+        return "";
+    }
+
+    protected getTextIconTooltip(): string {
+        return "";
+    }
+
+    protected getContainerClass(): string {
+        return "rx-child";
+    }
+}

--- a/src/containers/rx/untagged_container.ts
+++ b/src/containers/rx/untagged_container.ts
@@ -1,8 +1,8 @@
-import { ViewContainer } from "../view_container";
 import { App, getAllTags, Menu, MenuItem, moment, TFile } from "obsidian";
 import { ObloggerSettings, ContainerSortMethod, getSortMethodDisplayText, RxGroupType } from "../../settings";
 import { FileState } from "../../constants";
 import { ContainerCallbacks } from "../container_callbacks";
+import { RxContainer } from "./rx_container";
 
 interface RenderedFile {
     file: TFile;
@@ -10,7 +10,7 @@ interface RenderedFile {
     ctime: number;
 }
 
-export class UntaggedContainer extends ViewContainer {
+export class UntaggedContainer extends RxContainer {
     renderedFiles: RenderedFile[];
 
     constructor(
@@ -20,14 +20,12 @@ export class UntaggedContainer extends ViewContainer {
     ) {
         super(
             app,
-            RxGroupType.UNTAGGED,
-            false,
             settings,
-            true, // isMovable
-            false, // canCollapseInnerFolders
-            false, // canBePinned
-            false, // isPinned
-            callbacks);
+            callbacks,
+            RxGroupType.UNTAGGED,
+            false, // showStatusIcon,
+            false // canCollapseInnerFolders
+        );
     }
 
     protected wouldBeRendered(state: FileState): boolean {
@@ -65,28 +63,8 @@ export class UntaggedContainer extends ViewContainer {
         return "No untagged documents";
     }
 
-    protected getHideText(): string {
-        return "Hide";
-    }
-
-    protected getHideIcon(): string {
-        return "eye-off"
-    }
-
     protected getTitleText(): string {
         return "Untagged";
-    }
-
-    protected getTitleTooltip(): string {
-        return "";
-    }
-
-    protected getTextIcon(): string {
-        return "";
-    }
-
-    protected getTextIconTooltip(): string {
-        return "";
     }
 
     protected getPillText(): string {
@@ -155,10 +133,6 @@ export class UntaggedContainer extends ViewContainer {
 
             menu.showAtMouseEvent(e);
         }
-    }
-
-    protected getContainerClass(): string {
-        return "rx-child";
     }
 
     protected addFileToFolder(file: TFile, remainingTag:string, pathPrefix:string) {

--- a/src/containers/rx/untagged_container.ts
+++ b/src/containers/rx/untagged_container.ts
@@ -1,8 +1,8 @@
-import { FileClickCallback, FileAddedCallback } from "../group_folder";
 import { ViewContainer } from "../view_container";
 import { App, getAllTags, Menu, MenuItem, moment, TFile } from "obsidian";
 import { ObloggerSettings, ContainerSortMethod, getSortMethodDisplayText, RxGroupType } from "../../settings";
 import { FileState } from "../../constants";
+import { ContainerCallbacks } from "../container_callbacks";
 
 interface RenderedFile {
     file: TFile;
@@ -15,33 +15,19 @@ export class UntaggedContainer extends ViewContainer {
 
     constructor(
         app: App,
-        fileClickCallback: FileClickCallback,
-        fileAddedCallback: FileAddedCallback,
-        collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
-        requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => Promise<void>,
-        moveCallback: (up: boolean) => void,
-        hideCallback: () => void
+        callbacks: ContainerCallbacks
     ) {
         super(
             app,
             RxGroupType.UNTAGGED,
-            fileClickCallback,
-            fileAddedCallback,
-            collapseChangedCallback,
             false,
-            requestRenderCallback,
             settings,
-            saveSettingsCallback,
-            (isCollapsed) => isCollapsed ? "folder-closed" : "folder-open",
-            moveCallback,
-            hideCallback,
             true, // isMovable
             false, // canCollapseInnerFolders
             false, // canBePinned
-            undefined,
-            false); // isPinned
+            false, // isPinned
+            callbacks);
     }
 
     protected wouldBeRendered(state: FileState): boolean {
@@ -133,7 +119,7 @@ export class UntaggedContainer extends ViewContainer {
                     groupSetting.sortMethod = method;
                     groupSetting.sortAscending = true;
                 }
-                await this.saveSettingsCallback();
+                await this.callbacks.saveSettingsCallback();
                 this.requestRender();
             }
 

--- a/src/containers/view_container.ts
+++ b/src/containers/view_container.ts
@@ -1,6 +1,6 @@
 import { App, FrontMatterCache, Menu, setIcon, TFile } from "obsidian";
 import {FileClickCallback, GroupFolder, FileAddedCallback} from "./group_folder";
-import { GroupSettings, ObloggerSettings, OtcGroupSettings, RxGroupSettings } from "../settings";
+import { GroupSettings, ObloggerSettings } from "../settings";
 import { buildStateFromFile, FileState } from "../constants";
 import { FolderSuggestModal } from "../folder_suggest_modal";
 
@@ -519,7 +519,7 @@ export abstract class ViewContainer extends GroupFolder {
     public render(
         modifiedFiles: FileState[],
         forced: boolean,
-        groupSetting: OtcGroupSettings | RxGroupSettings
+        groupSetting: GroupSettings
     ) {
         const collapsedFolders = groupSetting.collapsedFolders ?? [];
         const excludedFolders = [...groupSetting.excludedFolders ?? []];

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,3 +1,8 @@
+// We're using deprecated symbols in this because we're loading possibly old
+// json settings and we want to keep track of previous (now deprecated) versions
+// of the settings objects
+// noinspection JSDeprecatedSymbols
+
 import { TFile } from "obsidian";
 
 export const ContainerSortMethod = {


### PR DESCRIPTION
part of greater change for #112 

depends on #117 

- creates new `ContainerCallbacks` object which groups together all of the callbacks needed for containers
- uses the `ContainerCallbacks` throughout the codebase
- updates the linting command so it collects all ts files