### PR TITLE
#112: extract callbacks into object

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "dev": "npx rollup --config rollup-debug.config.js -w",
         "build": "npx rollup --config rollup.config.js --environment BUILD:production",
         "version": "node scripts/version-bump.mjs && git add manifest.json versions.json",
-        "lint": "npx eslint src/*.ts"
+        "lint": "npx eslint src --ext .ts"
     },
     "keywords": [
         "obsidian",

--- a/src/containers/container_callbacks.ts
+++ b/src/containers/container_callbacks.ts
@@ -1,0 +1,13 @@
+import { FileAddedCallback, FileClickCallback } from "./group_folder";
+
+export interface ContainerCallbacks {
+    fileClickCallback: FileClickCallback;
+    fileAddedCallback: FileAddedCallback;
+    collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void;
+    requestRenderCallback: () => void;
+    saveSettingsCallback: () => Promise<void>;
+    getGroupIconCallback: (isCollapsed: boolean) => string,
+    hideCallback: () => void;
+    moveCallback: (up: boolean) => void;
+    pinCallback: ((pin: boolean) => void) | undefined;
+}

--- a/src/containers/otc/tag_group_container.ts
+++ b/src/containers/otc/tag_group_container.ts
@@ -1,8 +1,8 @@
 import { App, getAllTags, Menu, MenuItem, TFile } from "obsidian";
-import { FileClickCallback, FileAddedCallback } from "../group_folder";
 import { ViewContainer } from "../view_container";
 import { ContainerSortMethod, getSortMethodDisplayText, GroupSettings, ObloggerSettings } from "../../settings";
 import { FileState } from "../../constants";
+import { ContainerCallbacks } from "../container_callbacks";
 
 
 type TagFileMap = { [key: string]: TFile[] };
@@ -18,35 +18,20 @@ export class TagGroupContainer extends ViewContainer {
     constructor(
         app: App,
         baseTag: string,
-        removeCallback: () => void,
-        moveCallback: (up: boolean) => void,
-        fileClickCallback: FileClickCallback,
-        fileAddedCallback: FileAddedCallback,
-        collapseChangedCallback: (baseTag: string, collapsedFolders: string[], save: boolean) => void,
-        requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => Promise<void>,
-        pinCallback: (pin: boolean) => void,
-        isPinned: boolean
+        isPinned: boolean,
+        callbacks: ContainerCallbacks
     ) {
         super(
             app,
             baseTag,
-            fileClickCallback,
-            fileAddedCallback,
-            collapseChangedCallback,
             false,
-            requestRenderCallback,
             settings,
-            saveSettingsCallback,
-            (isCollapsed) => isCollapsed ? "folder-closed" : "folder-open",
-            moveCallback,
-            removeCallback,
             false, // isMovable
             true, // canCollapseInnerFolders
             true, // canBePinned
-            pinCallback,
-            isPinned
+            isPinned,
+            callbacks
         );
     }
 
@@ -184,7 +169,7 @@ export class TagGroupContainer extends ViewContainer {
                     groupSetting.sortMethod = method;
                     groupSetting.sortAscending = true;
                 }
-                await this.saveSettingsCallback();
+                await this.callbacks.saveSettingsCallback();
                 this.requestRender();
             }
 

--- a/src/containers/rx/dailies_container.ts
+++ b/src/containers/rx/dailies_container.ts
@@ -1,42 +1,28 @@
 import { App, FrontMatterCache, getAllTags, Menu, moment, Notice, TFile } from "obsidian";
-import { FileClickCallback, FileAddedCallback } from "../group_folder";
 import { ViewContainer } from "../view_container";
 import { ObloggerSettings, RxGroupType } from "../../settings";
 import { NewTagModal } from "../../new_tag_modal";
 import { FileState } from "../../constants";
+import { ContainerCallbacks } from "../container_callbacks";
 
 export class DailiesContainer extends ViewContainer {
     fileEntryDates: { file: TFile, date: string }[]
 
     constructor(
         app: App,
-        fileClickCallback: FileClickCallback,
-        fileAddedCallback: FileAddedCallback,
-        collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
-        requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => Promise<void>,
-        moveCallback: (up: boolean) => void,
-        hideCallback: () => void
+        callbacks: ContainerCallbacks
     ) {
         super(
             app,
             RxGroupType.DAILIES,
-            fileClickCallback,
-            fileAddedCallback,
-            collapseChangedCallback,
             false, // showStatusIcon
-            requestRenderCallback,
             settings,
-            saveSettingsCallback,
-            (isCollapsed) => isCollapsed ? "folder-closed" : "folder-open",
-            moveCallback,
-            hideCallback,
             true, // isMovable
             true, // canCollapseInnerFolders
             false, // canBePinned
-            undefined,
-            false); // isPinned
+            false, // isPinned
+            callbacks);
 
         this.fileEntryDates = [];
     }
@@ -113,7 +99,7 @@ export class DailiesContainer extends ViewContainer {
                             return;
                         }
                         this.settings.dailiesTag = result;
-                        this.saveSettingsCallback();
+                        await this.callbacks.saveSettingsCallback();
                         this.requestRender();
                     });
                     modal.open();

--- a/src/containers/rx/files_container.ts
+++ b/src/containers/rx/files_container.ts
@@ -1,39 +1,28 @@
 import { ViewContainer } from "../view_container";
-import { FileAddedCallback, FileClickCallback } from "../group_folder";
 import { ObloggerSettings, ContainerSortMethod, getSortMethodDisplayText, RxGroupType, getFileType } from "../../settings";
 import { App, Menu, MenuItem, moment, TFile } from "obsidian";
 import { FileState } from "../../constants";
+import { ContainerCallbacks } from "../container_callbacks";
 
 export class FilesContainer extends ViewContainer {
     constructor(
         app: App,
-        fileClickCallback: FileClickCallback,
-        fileAddedCallback: FileAddedCallback,
-        collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
-        requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => Promise<void>,
-        moveCallback: (up: boolean) => void,
-        hideCallback: () => void
+        callbacks: ContainerCallbacks
     ) {
+        // Override the default behavior with special packaging
+        callbacks.getGroupIconCallback = (isCollapsed) => isCollapsed ? "package" : "package-open";
+
         super(
             app,
             RxGroupType.FILES,
-            fileClickCallback,
-            fileAddedCallback,
-            collapseChangedCallback,
             false,
-            requestRenderCallback,
             settings,
-            saveSettingsCallback,
-            (isCollapsed) => isCollapsed ? "package" : "package-open",
-            moveCallback,
-            hideCallback,
             true, // isMovable
             true, // canCollapseInnerFolders
             false, // canBePinned
-            undefined,
-            false); // isPinned
+            false, // isPinned
+            callbacks);
     }
 
     protected wouldBeRendered(state: FileState): boolean {
@@ -108,7 +97,7 @@ export class FilesContainer extends ViewContainer {
                     groupSetting.sortMethod = method;
                     groupSetting.sortAscending = true;
                 }
-                await this.saveSettingsCallback();
+                await this.callbacks.saveSettingsCallback();
                 this.requestRender();
             }
 

--- a/src/containers/rx/recents_container.ts
+++ b/src/containers/rx/recents_container.ts
@@ -1,8 +1,8 @@
-import {FileClickCallback, FileAddedCallback } from "../group_folder";
 import { ViewContainer } from "../view_container";
 import { App, Menu } from "obsidian";
 import { ObloggerSettings, RxGroupType } from "../../settings";
 import { FileState } from "../../constants";
+import { ContainerCallbacks } from "../container_callbacks";
 
 const RECENT_COUNT_OPTIONS = [5, 10, 15];
 
@@ -11,33 +11,19 @@ export class RecentsContainer extends ViewContainer {
 
     constructor(
         app: App,
-        fileClickCallback: FileClickCallback,
-        fileAddedCallback: FileAddedCallback,
-        collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
-        requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => Promise<void>,
-        moveCallback: (up: boolean) => void,
-        hideCallback: () => void
+        callbacks: ContainerCallbacks
     ) {
         super(
             app,
             RxGroupType.RECENTS,
-            fileClickCallback,
-            fileAddedCallback,
-            collapseChangedCallback,
             true,
-            requestRenderCallback,
             settings,
-            saveSettingsCallback,
-            (isCollapsed) => isCollapsed ? "folder-closed" : "folder-open",
-            moveCallback,
-            hideCallback,
             true, // isMovable
             false, // canCollapseInnerFolders
             false, // canBePinned
-            undefined,
-            false); // isPinned
+            false, // isPinned
+            callbacks);
 
         this.recentsCount = settings.recentsCount;
     }
@@ -104,7 +90,7 @@ export class RecentsContainer extends ViewContainer {
                         this.recentsCount = amount;
                         this.requestRender();
                         this.settings.recentsCount = amount;
-                        this.saveSettingsCallback();
+                        return this.callbacks.saveSettingsCallback();
                     });
                     item.setIcon(this.recentsCount === amount ? "check" : "");
                     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/containers/rx/untagged_container.ts
+++ b/src/containers/rx/untagged_container.ts
@@ -1,8 +1,8 @@
-import { FileClickCallback, FileAddedCallback } from "../group_folder";
 import { ViewContainer } from "../view_container";
 import { App, getAllTags, Menu, MenuItem, moment, TFile } from "obsidian";
 import { ObloggerSettings, ContainerSortMethod, getSortMethodDisplayText, RxGroupType } from "../../settings";
 import { FileState } from "../../constants";
+import { ContainerCallbacks } from "../container_callbacks";
 
 interface RenderedFile {
     file: TFile;
@@ -15,33 +15,19 @@ export class UntaggedContainer extends ViewContainer {
 
     constructor(
         app: App,
-        fileClickCallback: FileClickCallback,
-        fileAddedCallback: FileAddedCallback,
-        collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void,
-        requestRenderCallback: () => void,
         settings: ObloggerSettings,
-        saveSettingsCallback: () => Promise<void>,
-        moveCallback: (up: boolean) => void,
-        hideCallback: () => void
+        callbacks: ContainerCallbacks
     ) {
         super(
             app,
             RxGroupType.UNTAGGED,
-            fileClickCallback,
-            fileAddedCallback,
-            collapseChangedCallback,
             false,
-            requestRenderCallback,
             settings,
-            saveSettingsCallback,
-            (isCollapsed) => isCollapsed ? "folder-closed" : "folder-open",
-            moveCallback,
-            hideCallback,
             true, // isMovable
             false, // canCollapseInnerFolders
             false, // canBePinned
-            undefined,
-            false); // isPinned
+            false, // isPinned
+            callbacks);
     }
 
     protected wouldBeRendered(state: FileState): boolean {
@@ -133,7 +119,7 @@ export class UntaggedContainer extends ViewContainer {
                     groupSetting.sortMethod = method;
                     groupSetting.sortAscending = true;
                 }
-                await this.saveSettingsCallback();
+                await this.callbacks.saveSettingsCallback();
                 this.requestRender();
             }
 

--- a/src/containers/view_container.ts
+++ b/src/containers/view_container.ts
@@ -1,6 +1,6 @@
 import { App, FrontMatterCache, Menu, setIcon, TFile } from "obsidian";
 import {FileClickCallback, GroupFolder, FileAddedCallback} from "./group_folder";
-import { GroupSettings, ObloggerSettings, OtcGroupSettings, RxGroupSettings } from "../settings";
+import { GroupSettings, ObloggerSettings } from "../settings";
 import { buildStateFromFile, FileState } from "../constants";
 import { FolderSuggestModal } from "../folder_suggest_modal";
 
@@ -519,7 +519,7 @@ export abstract class ViewContainer extends GroupFolder {
     public render(
         modifiedFiles: FileState[],
         forced: boolean,
-        groupSetting: OtcGroupSettings | RxGroupSettings
+        groupSetting: GroupSettings
     ) {
         const collapsedFolders = groupSetting.collapsedFolders ?? [];
         const excludedFolders = [...groupSetting.excludedFolders ?? []];


### PR DESCRIPTION
part of greater change for #112 

depends on #117 

- creates new `ContainerCallbacks` object which groups together all of the callbacks needed for containers
- uses the `ContainerCallbacks` throughout the codebase
- updates the linting command so it collects all ts files