### PR TITLE
let the test vault update the core plugins migration file

### DIFF
--- a/test-vault/.obsidian/core-plugins-migration.json
+++ b/test-vault/.obsidian/core-plugins-migration.json
@@ -25,5 +25,6 @@
   "workspaces": false,
   "file-recovery": true,
   "publish": false,
-  "sync": false
+  "sync": false,
+  "properties": false
 }


### PR DESCRIPTION
when obsidian is launching the test vault, it keeps wanting to change this file. let it change it