### PR TITLE
#112: add group type

### DIFF
--- a/src/containers/container_callbacks.ts
+++ b/src/containers/container_callbacks.ts
@@ -3,7 +3,6 @@ import { FileAddedCallback, FileClickCallback } from "./group_folder";
 export interface ContainerCallbacks {
     fileClickCallback: FileClickCallback;
     fileAddedCallback: FileAddedCallback;
-    collapseChangedCallback: (groupName: string, collapsedFolders: string[], save: boolean) => void;
     requestRenderCallback: () => void;
     saveSettingsCallback: () => Promise<void>;
     getGroupIconCallback: (isCollapsed: boolean) => string,

--- a/src/containers/otc/tag_group_container.ts
+++ b/src/containers/otc/tag_group_container.ts
@@ -1,6 +1,12 @@
 import { App, getAllTags, Menu, TFile } from "obsidian";
 import { ViewContainer } from "../view_container";
-import { ContainerSortMethod, getSortMethodDisplayText, GroupSettings, ObloggerSettings } from "../../settings";
+import {
+    ContainerSortMethod,
+    getSortMethodDisplayText,
+    GroupSettings,
+    ObloggerSettings,
+    OtcGroupType
+} from "../../settings";
 import { FileState } from "../../constants";
 import { ContainerCallbacks } from "../container_callbacks";
 
@@ -25,6 +31,7 @@ export class TagGroupContainer extends ViewContainer {
         super(
             app,
             baseTag,
+            OtcGroupType.TAG_GROUP,
             false, // showStatusIcon
             settings,
             false, // isMovable
@@ -35,7 +42,7 @@ export class TagGroupContainer extends ViewContainer {
         );
     }
 
-    protected getGroupSetting(): GroupSettings | undefined {
+    protected getGroupSettings(): GroupSettings | undefined {
         // override to search otcGroups instead of rxGroups
         return this.settings.otcGroups.find(group => group.groupName === this.groupName);
     }
@@ -109,7 +116,7 @@ export class TagGroupContainer extends ViewContainer {
     }
 
     protected getPillText(): string {
-        return getSortMethodDisplayText(this.getGroupSetting()?.sortMethod ?? ContainerSortMethod.ALPHABETICAL);
+        return getSortMethodDisplayText(this.getGroupSettings()?.sortMethod ?? ContainerSortMethod.ALPHABETICAL);
     }
 
     protected getPillTooltipText(): string {
@@ -127,7 +134,7 @@ export class TagGroupContainer extends ViewContainer {
     }
 
     protected getPillIcon(): string {
-        return (this.getGroupSetting()?.sortAscending ?? true) ?
+        return (this.getGroupSettings()?.sortAscending ?? true) ?
             "down-arrow-with-tail" :
             "up-arrow-with-tail"
     }
@@ -227,8 +234,8 @@ export class TagGroupContainer extends ViewContainer {
 
         const tagFiles = this.getAllAssociatedTags(excludedFolders);
         const isolatedGroupName = this.getIsolatedTagMatch()?.at(1);
-        const ascending = this.getGroupSetting()?.sortAscending ?? true;
-        const sortMethod = this.getGroupSetting()?.sortMethod ?? ContainerSortMethod.ALPHABETICAL;
+        const ascending = this.getGroupSettings()?.sortAscending ?? true;
+        const sortMethod = this.getGroupSettings()?.sortMethod ?? ContainerSortMethod.ALPHABETICAL;
         const fileSortingFn = this.getFileSortingFn(sortMethod);
 
         Object.keys(tagFiles).sort((tagA: string, tagB: string) => {

--- a/src/containers/rx/files_container.ts
+++ b/src/containers/rx/files_container.ts
@@ -43,7 +43,7 @@ export class FilesContainer extends RxContainer {
     }
 
     protected getPillIcon(): string {
-        return this.getGroupSetting()?.sortAscending ?
+        return this.getGroupSettings()?.sortAscending ?
             "down-arrow-with-tail" :
             "up-arrow-with-tail"
     }
@@ -53,7 +53,7 @@ export class FilesContainer extends RxContainer {
     }
 
     protected getPillText(): string {
-        return getSortMethodDisplayText(this.getGroupSetting()?.sortMethod ?? ContainerSortMethod.ALPHABETICAL);
+        return getSortMethodDisplayText(this.getGroupSettings()?.sortMethod ?? ContainerSortMethod.ALPHABETICAL);
     }
 
     protected getPillClickHandler(): ((e: MouseEvent) => void) | undefined {
@@ -142,9 +142,9 @@ export class FilesContainer extends RxContainer {
             return file.extension !== "md";
         });
 
-        const ascending = this.getGroupSetting()?.sortAscending ?? true;
+        const ascending = this.getGroupSettings()?.sortAscending ?? true;
 
-        switch (this.getGroupSetting()?.sortMethod ?? ContainerSortMethod.TYPE) {
+        switch (this.getGroupSettings()?.sortMethod ?? ContainerSortMethod.TYPE) {
             case ContainerSortMethod.ALPHABETICAL:
                 this.buildAlphabeticalFileStructure(includedFiles, ascending);
                 break;

--- a/src/containers/rx/recents_container.ts
+++ b/src/containers/rx/recents_container.ts
@@ -85,7 +85,6 @@ export class RecentsContainer extends RxContainer {
     }
 
     protected buildFileStructure(excludedFolders: string[]): void {
-        console.log(excludedFolders)
         let foundFilesCount = 0;
         this.app.vault
             .getFiles()

--- a/src/containers/rx/rx_container.ts
+++ b/src/containers/rx/rx_container.ts
@@ -1,5 +1,5 @@
 import { ViewContainer } from "../view_container";
-import { ObloggerSettings } from "../../settings";
+import { ObloggerSettings, RxGroupType } from "../../settings";
 import { ContainerCallbacks } from "../container_callbacks";
 import { App } from "obsidian";
 
@@ -8,13 +8,14 @@ export abstract class RxContainer extends ViewContainer {
         app: App,
         settings: ObloggerSettings,
         callbacks: ContainerCallbacks,
-        groupType: string,
+        groupType: RxGroupType,
         showStatusIcon: boolean,
         canCollapseInnerFolders: boolean
     ) {
         super(
             app,
-            groupType, // viewName
+            "", // viewName
+            groupType,
             showStatusIcon,
             settings,
             true, // isMovable

--- a/src/containers/rx/untagged_container.ts
+++ b/src/containers/rx/untagged_container.ts
@@ -48,7 +48,7 @@ export class UntaggedContainer extends RxContainer {
     }
 
     protected getPillText(): string {
-        return getSortMethodDisplayText(this.getGroupSetting()?.sortMethod ?? ContainerSortMethod.ALPHABETICAL);
+        return getSortMethodDisplayText(this.getGroupSettings()?.sortMethod ?? ContainerSortMethod.ALPHABETICAL);
     }
 
     protected getPillTooltipText(): string {
@@ -56,7 +56,7 @@ export class UntaggedContainer extends RxContainer {
     }
 
     protected getPillIcon(): string {
-        return this.getGroupSetting()?.sortAscending ?
+        return this.getGroupSettings()?.sortAscending ?
             "down-arrow-with-tail" :
             "up-arrow-with-tail"
     }
@@ -131,22 +131,22 @@ export class UntaggedContainer extends RxContainer {
             return cache !== null && ((getAllTags(cache)?.length ?? 1) <= 0);
         });
 
-        switch (this.getGroupSetting()?.sortMethod) {
+        switch (this.getGroupSettings()?.sortMethod) {
             case ContainerSortMethod.ALPHABETICAL:
                 this.buildAlphabeticalFileStructure(
                     includedFiles,
-                    this.getGroupSetting()?.sortAscending ?? true);
+                    this.getGroupSettings()?.sortAscending ?? true);
                 break;
             case ContainerSortMethod.CTIME:
                 this.buildDateFileStructure(
                     includedFiles,
-                    this.getGroupSetting()?.sortAscending ?? true,
+                    this.getGroupSettings()?.sortAscending ?? true,
                     true);
                 break;
             case ContainerSortMethod.MTIME:
                 this.buildDateFileStructure(
                     includedFiles,
-                    this.getGroupSetting()?.sortAscending ?? true,
+                    this.getGroupSettings()?.sortAscending ?? true,
                     false);
                 break;
         }

--- a/src/containers/view_container.ts
+++ b/src/containers/view_container.ts
@@ -4,8 +4,10 @@ import {
     ContainerSortMethod,
     getGroupSettings,
     getSortMethodDisplayText,
-    GroupSettings, GroupType, isValidGroupType,
-    ObloggerSettings, OtcGroupType, RxGroupType
+    GroupSettings,
+    GroupType,
+    isValidGroupType,
+    ObloggerSettings
 } from "../settings";
 import { buildStateFromFile, FileState } from "../constants";
 import { FolderSuggestModal } from "../folder_suggest_modal";

--- a/src/containers/view_container.ts
+++ b/src/containers/view_container.ts
@@ -1,6 +1,12 @@
 import { App, FrontMatterCache, Menu, MenuItem, moment, setIcon, TFile } from "obsidian";
 import { GroupFolder } from "./group_folder";
-import { ContainerSortMethod, getSortMethodDisplayText, GroupSettings, ObloggerSettings } from "../settings";
+import {
+    ContainerSortMethod,
+    getGroupSettings,
+    getSortMethodDisplayText,
+    GroupSettings, GroupType, isValidGroupType,
+    ObloggerSettings, OtcGroupType, RxGroupType
+} from "../settings";
 import { buildStateFromFile, FileState } from "../constants";
 import { FolderSuggestModal } from "../folder_suggest_modal";
 import { ContainerCallbacks } from "./container_callbacks";
@@ -17,6 +23,7 @@ export abstract class ViewContainer extends GroupFolder {
     canBePinned: boolean;
     isPinned: boolean;
     renderedFileCaches: RenderedFileCache[]
+    groupType: GroupType;
 
     callbacks: ContainerCallbacks;
 
@@ -42,6 +49,7 @@ export abstract class ViewContainer extends GroupFolder {
     protected constructor(
         app: App,
         viewName: string,
+        groupType: GroupType,
         showStatusIcon: boolean,
         settings: ObloggerSettings,
         isMovable: boolean,
@@ -55,13 +63,28 @@ export abstract class ViewContainer extends GroupFolder {
             viewName,
             "/",
             (save: boolean) => {
-                callbacks.collapseChangedCallback(viewName, this.getCollapsedFolders(), save);
+                if (!save) {
+                    return;
+                }
+                const groupSetting = getGroupSettings(
+                    this.settings,
+                    groupType,
+                    viewName);
+                if (groupSetting) {
+                    groupSetting.collapsedFolders = this.getCollapsedFolders();
+                    return callbacks.saveSettingsCallback();
+                }
             },
             showStatusIcon,
             callbacks.getGroupIconCallback,
             () => { return this.getEmptyMessage() });
 
+        if (!isValidGroupType(groupType)) {
+            console.warn(`Unknown group type ${groupType} with name ${viewName}. Continuing...`);
+        }
+
         this.settings = settings;
+        this.groupType = groupType;
         this.isMovable = isMovable;
         this.canCollapseInnerFolders = canCollapseInnerFolders;
         this.canBePinned = canBePinned;
@@ -80,14 +103,12 @@ export abstract class ViewContainer extends GroupFolder {
         super.addFileToFolder(file, remainingTag, pathPrefix);
     }
 
-    protected isVisible(): boolean {
-        return this.getGroupSetting()?.isVisible ?? true;
+    protected getGroupSettings(): GroupSettings | undefined {
+        return getGroupSettings(this.settings, this.groupType, this.groupName);
     }
 
-    protected getGroupSetting(): GroupSettings | undefined {
-        // default to fetching from rx groups. override in TagGroupContainer
-        // to fetch from otc groups.
-        return this.settings.rxGroups.find(group => group.groupName === this.groupName);
+    protected isVisible(): boolean {
+        return this.getGroupSettings()?.isVisible ?? true;
     }
 
     protected requestRender() {
@@ -96,7 +117,7 @@ export abstract class ViewContainer extends GroupFolder {
 
     protected addSortOptionsToMenu(menu: Menu, sortMethods: string[]) {
         const changeSortMethod = async (method: string) => {
-            const groupSetting = this.getGroupSetting();
+            const groupSetting = this.getGroupSettings();
             if (groupSetting === undefined) {
                 return;
             }
@@ -116,13 +137,13 @@ export abstract class ViewContainer extends GroupFolder {
                 return changeSortMethod(method);
             });
 
-            if (method === this.getGroupSetting()?.sortMethod) {
+            if (method === this.getGroupSettings()?.sortMethod) {
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore
                 item.iconEl.addClass("untagged-sort-confirmation");
 
                 item.setIcon(
-                    this.getGroupSetting()?.sortAscending ?
+                    this.getGroupSettings()?.sortAscending ?
                         "down-arrow-with-tail" :
                         "up-arrow-with-tail");
             } else {
@@ -142,7 +163,7 @@ export abstract class ViewContainer extends GroupFolder {
         oldState: FileState,
         newState: FileState
     ): boolean {
-        const groupSettings = this.getGroupSetting();
+        const groupSettings = this.getGroupSettings();
         switch(groupSettings?.sortMethod) {
             case ContainerSortMethod.ALPHABETICAL:
                 // shouldn't actually happen because we should be deciding
@@ -258,7 +279,7 @@ export abstract class ViewContainer extends GroupFolder {
             );
         }
 
-        const groupSetting = this.getGroupSetting();
+        const groupSetting = this.getGroupSettings();
 
         menu.addItem(item => {
             item

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -16,7 +16,8 @@ import {
     ContainerSortMethod,
     OtcGroupType,
     getGroupSettings,
-    isValidRxGroupType
+    isValidRxGroupType,
+    areEnumsValid
 } from "./settings";
 import { TagGroupContainer } from "./containers/otc/tag_group_container";
 import { DailiesContainer } from "./containers/rx/dailies_container";
@@ -77,6 +78,10 @@ export class ObloggerView extends ItemView {
         saveSettingsCallback: () => Promise<void>
     ) {
         super(leaf);
+
+        // If there's a way to do this at compile time, then we should do that.
+        // But for now, a console assert is better than nothing.
+        console.assert(areEnumsValid());
 
         this.fullRender = true;
         this.settings = settings;

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -8,7 +8,7 @@ import {
     Notice,
     CachedMetadata
 } from "obsidian";
-import { ObloggerSettings, RxGroupType, GroupSettings, ContainerSortMethod } from "./settings";
+import { ObloggerSettings, RxGroupType, GroupSettings, ContainerSortMethod, OtcGroupType } from "./settings";
 import { TagGroupContainer } from "./containers/otc/tag_group_container";
 import { DailiesContainer } from "./containers/rx/dailies_container";
 import { FileClickCallback, GroupFolder } from "./containers/group_folder";
@@ -234,7 +234,12 @@ export class ObloggerView extends ItemView {
                 return;
             }
             const group = this.settings?.otcGroups.find(
-                group => group.groupName === groupName
+                group => {
+                    return (
+                        group.groupType === OtcGroupType.TAG_GROUP &&
+                        group.groupName === groupName
+                    );
+                }
             );
             if (!group) {
                 new Notice(`Unable to find tag ${groupName} to update the collapse for.`);
@@ -530,6 +535,7 @@ export class ObloggerView extends ItemView {
             }
             this.settings.otcGroups.push({
                 groupName: result,
+                groupType: OtcGroupType.TAG_GROUP,
                 collapsedFolders: [],
                 isVisible: true,
                 isPinned: false,

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -8,7 +8,14 @@ import {
     Notice,
     CachedMetadata
 } from "obsidian";
-import { ObloggerSettings, RxGroupType, GroupSettings, ContainerSortMethod, OtcGroupType } from "./settings";
+import {
+    ObloggerSettings,
+    RxGroupType,
+    GroupSettings,
+    ContainerSortMethod,
+    OtcGroupType,
+    getGroupSettings
+} from "./settings";
 import { TagGroupContainer } from "./containers/otc/tag_group_container";
 import { DailiesContainer } from "./containers/rx/dailies_container";
 import { FileClickCallback, GroupFolder } from "./containers/group_folder";
@@ -233,14 +240,10 @@ export class ObloggerView extends ItemView {
             if (!save) {
                 return;
             }
-            const group = this.settings?.otcGroups.find(
-                group => {
-                    return (
-                        group.groupType === OtcGroupType.TAG_GROUP &&
-                        group.groupName === groupName
-                    );
-                }
-            );
+            const group = getGroupSettings(
+                this.settings,
+                OtcGroupType.TAG_GROUP,
+                groupName);
             if (!group) {
                 new Notice(`Unable to find tag ${groupName} to update the collapse for.`);
                 return;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -153,7 +153,7 @@ interface ObloggerSettings_v5 extends ObloggerSettings_v4 {
     otcGroups: GroupSettings_v1[];
 }
 
-export type ObloggerSettings = ObloggerSettings_v5
+export type ObloggerSettings = ObloggerSettings_v5;
 
 const UPGRADE_FUNCTIONS: {[id: number]: (settings: ObloggerSettings) => void } = {
     0: (settings: ObloggerSettings) => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -57,6 +57,25 @@ export const isValidOtcGroupType = (groupType: OtcGroupType): boolean => {
 
 export type GroupType = RxGroupType | OtcGroupType;
 
+export const areEnumsValid = (): boolean => {
+    const allEnums = Object
+        .entries(RxGroupType)
+        .map((rxGroupType) => {
+            return [rxGroupType.first(), String(rxGroupType.last())];
+        }).concat(
+            Object
+                .entries(OtcGroupType)
+                .map((otcGroupType) => {
+                    return [otcGroupType.first(), String(otcGroupType.last())];
+                })
+        );
+    console.log(allEnums);
+    return !allEnums
+        .some(groupType => {
+            return groupType.first()?.toLowerCase() !== groupType.last();
+        });
+}
+
 export const isValidGroupType = (groupType: GroupType): boolean => {
     return (
         isValidRxGroupType(groupType as RxGroupType) ||

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -37,6 +37,15 @@ export const RxGroupType = {
     DAILIES: "dailies"
 }
 
+export const OtcGroupType = {
+    TAG_GROUP: "tag_group"
+}
+
+export const GroupType = {
+    ...RxGroupType,
+    ...OtcGroupType
+}
+
 interface RxGroupSettings_v0 {
     groupName: string;
     collapsedFolders: string[];
@@ -75,7 +84,7 @@ interface OtcGroupSettings_v1 extends OtcGroupSettings_v0 {
  */
 export type OtcGroupSettings = OtcGroupSettings_v1;
 
-export interface GroupSettings {
+export interface GroupSettings_v0 {
     groupName: string;
     collapsedFolders: string[];
     isPinned: boolean;
@@ -86,6 +95,12 @@ export interface GroupSettings {
     templatesFolderVisible: boolean;
     logsFolderVisible: boolean;
 }
+
+export interface GroupSettings_v1 extends GroupSettings_v0 {
+    groupType: string;
+}
+
+export type GroupSettings = GroupSettings_v1;
 
 export const PostLogAction = {
     QUIETLY: "quietly",
@@ -129,11 +144,16 @@ interface ObloggerSettings_v3 extends ObloggerSettings_v2 {
 }
 
 interface ObloggerSettings_v4 extends ObloggerSettings_v3 {
-    rxGroups: GroupSettings[];
-    otcGroups: GroupSettings[];
+    rxGroups: GroupSettings_v0[];
+    otcGroups: GroupSettings_v0[];
 }
 
-export type ObloggerSettings = ObloggerSettings_v4
+interface ObloggerSettings_v5 extends ObloggerSettings_v4 {
+    rxGroups: GroupSettings_v1[];
+    otcGroups: GroupSettings_v1[];
+}
+
+export type ObloggerSettings = ObloggerSettings_v5
 
 const UPGRADE_FUNCTIONS: {[id: number]: (settings: ObloggerSettings) => void } = {
     0: (settings: ObloggerSettings) => {
@@ -204,6 +224,19 @@ const UPGRADE_FUNCTIONS: {[id: number]: (settings: ObloggerSettings) => void } =
             newSettings.tagGroups = [];
 
             newSettings.version = 4;
+        }
+    },
+    4: (settings: ObloggerSettings) => {
+        const newSettings = settings as ObloggerSettings_v5;
+        if (newSettings) {
+            newSettings.rxGroups.forEach(group => {
+                group.groupType = group.groupName;
+                group.groupName = "";
+            });
+            newSettings.otcGroups.forEach(group => {
+                group.groupType = OtcGroupType.TAG_GROUP;
+            })
+            newSettings.version = 5;
         }
     }
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -37,6 +37,10 @@ export const RxGroupType = {
     DAILIES: "dailies"
 }
 
+export const isValidRxGroupType = (groupType: string): boolean => {
+    return Object.values(RxGroupType).contains(groupType);
+}
+
 export const OtcGroupType = {
     TAG_GROUP: "tag_group"
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -69,7 +69,6 @@ export const areEnumsValid = (): boolean => {
                     return [otcGroupType.first(), String(otcGroupType.last())];
                 })
         );
-    console.log(allEnums);
     return !allEnums
         .some(groupType => {
             return groupType.first()?.toLowerCase() !== groupType.last();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -57,6 +57,18 @@ export const isValidOtcGroupType = (groupType: OtcGroupType): boolean => {
 
 export type GroupType = RxGroupType | OtcGroupType;
 
+export const isValidGroupType = (groupType: GroupType): boolean => {
+    return (
+        isValidRxGroupType(groupType as RxGroupType) ||
+        isValidOtcGroupType(groupType as OtcGroupType)
+    );
+}
+
+/**
+ * @description:validates that the enums are properly formed (that the
+ * key.toLowerCase() equals the value). should be called on launch (or better
+ * yet, at compile time).
+ */
 export const areEnumsValid = (): boolean => {
     const allEnums = Object
         .entries(RxGroupType)
@@ -73,13 +85,6 @@ export const areEnumsValid = (): boolean => {
         .some(groupType => {
             return groupType.first()?.toLowerCase() !== groupType.last();
         });
-}
-
-export const isValidGroupType = (groupType: GroupType): boolean => {
-    return (
-        isValidRxGroupType(groupType as RxGroupType) ||
-        isValidOtcGroupType(groupType as OtcGroupType)
-    );
 }
 
 interface RxGroupSettings_v0 {
@@ -288,6 +293,12 @@ const UPGRADE_FUNCTIONS: {[id: number]: (settings: ObloggerSettings) => void } =
     }
 };
 
+/**
+ * Takes in a version number and a settings object and attempts to upgrade
+ * the settings object to the next version.
+ * @param currentVersion Current version of the settings object
+ * @param settings Settings object to upgrade
+ */
 export const upgradeSettings = (currentVersion: number, settings: ObloggerSettings) => {
     const availableUpgrades = Object.keys(UPGRADE_FUNCTIONS);
     if (!availableUpgrades.contains(currentVersion.toString())) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -311,6 +311,19 @@ export const DEFAULT_SETTINGS: ObloggerSettings_v3 = {
     dailiesTag: "daily"
 };
 
+export const getGroupSettings = (
+    settings: ObloggerSettings,
+    groupType: string,
+    groupName: string
+): GroupSettings | undefined => {
+    return [
+        ...settings.otcGroups,
+        ...settings.rxGroups
+    ].find((group: GroupSettings) => {
+        return group.groupType === groupType && group.groupName === groupName
+    });
+}
+
 export enum FileType {
     image = "image",
     audio = "audio",


### PR DESCRIPTION
part of #112 

- changes `RxGroupType` and `OtcGroupType` to proper `enum`s. This is a little annoying because TS doesn't have great string enum support, so we lose out on some easy run-time validation. But we gain compile-time validation and get to keep the readability of `data.json`
- removes the collapse callback in favor of handling it in the view container
- renames `getGroupSetting` to `getGroupSettings`
- removes unnecessary console print
- uses centralized `getGroupSettings()` function instead of looping through settings each time
- adds `groupType` to `GroupSettings`
  - type includes each of the rx groups and `tag_groups`. Later, we'll add more otc group types and the group name will be the disambiguation value between them. So adding a tag group for "gardening" becomes `groupType = RxGroupType.TAG_GROUP` and `groupName = "gardening"`. All rx groups have `groupName = ""` for now unless we need to add a name.
- renames `Otc*` functions that are specifically dealing with tags to be specific to the tag group container. This change might be undone when we actually implement the next otc group, but for now it serves to break the assumption that all otc groups are tag groups.
- uses `groupType` instead of `groupName` for rx group identification
- uses new `RxGroupType` and `OtcGroupType` types instead of the more generic `string`