### PR TITLE
#112: create otc group container

### DIFF
--- a/src/containers/otc/otc_container.ts
+++ b/src/containers/otc/otc_container.ts
@@ -1,0 +1,105 @@
+import { ViewContainer } from "../view_container";
+import { ContainerSortMethod, getSortMethodDisplayText, ObloggerSettings, OtcGroupType } from "../../settings";
+import { ContainerCallbacks } from "../container_callbacks";
+import { App, Menu, TFile } from "obsidian";
+import { FileState } from "../../constants";
+
+export abstract class OtcContainer extends ViewContainer {
+    protected constructor(
+        app: App,
+        settings: ObloggerSettings,
+        callbacks: ContainerCallbacks,
+        groupType: OtcGroupType,
+        groupName: string,
+        isPinned: boolean
+    ) {
+        super(
+            app,
+            groupName,
+            groupType,
+            false, // showStatusIcon
+            settings,
+            false, // isMovable
+            true, // canCollapseInnerFolders
+            true, // canBePinned
+            isPinned,
+            callbacks
+        );
+    }
+
+    protected getHideText(): string {
+        return "Remove";
+    }
+
+    protected getHideIcon(): string {
+        return "trash"
+    }
+
+    protected isVisible(): boolean {
+        return true;
+    }
+
+    protected getPillText(): string {
+        return getSortMethodDisplayText(this.getGroupSettings()?.sortMethod ?? ContainerSortMethod.ALPHABETICAL);
+    }
+
+    protected getPillTooltipText(): string {
+        return "Sort";
+    }
+
+    protected getPillIcon(): string {
+        return (this.getGroupSettings()?.sortAscending ?? true) ?
+            "down-arrow-with-tail" :
+            "up-arrow-with-tail"
+    }
+
+    protected getPillClickHandler(): ((e: MouseEvent) => void) | undefined {
+        return (e: MouseEvent) => {
+            const menu = new Menu();
+
+            this.addSortOptionsToMenu(
+                menu,
+                [
+                    ContainerSortMethod.ALPHABETICAL,
+                    ContainerSortMethod.CTIME,
+                    ContainerSortMethod.MTIME
+                ]
+            );
+
+            menu.showAtMouseEvent(e);
+        }
+    }
+
+    protected getContainerClass(): string {
+        return "otc-child";
+    }
+
+    protected getFileSortingFn(sortMethod: string) {
+        switch (sortMethod) {
+            case ContainerSortMethod.MTIME:
+                return (fileA: TFile, fileB: TFile) => {
+                    return fileA.stat.mtime - fileB.stat.mtime;
+                }
+            case ContainerSortMethod.CTIME:
+                return (fileA: TFile, fileB: TFile) => {
+                    return fileA.stat.ctime - fileB.stat.ctime;
+                }
+            case ContainerSortMethod.ALPHABETICAL:
+            default:
+                return (fileA: TFile, fileB: TFile) => {
+                    return fileA.name < fileB.name ? -1 : fileA.name > fileB.name ? 1 : 0;
+                }
+        }
+    }
+
+    protected getEmptyMessage(): string {
+        return "";
+    }
+
+    protected shouldRender(
+        oldState: FileState,
+        newState: FileState
+    ): boolean {
+        return this.shouldRenderBasedOnSortMethodSetting(oldState, newState);
+    }
+}


### PR DESCRIPTION
part of #112 
depends on and merges into #124 

- creates new `OtcContainer` class
  - adds code from `TagGroupContainer` class that is likely to be common between new otc groups
- makes `TagGroupContainer` inherit from `OtcContainer` instead of `ViewContainer`
  - removes the now duplicated code
  - simplifies the constructor call