### PR TITLE
#112: property groups

### DIFF
--- a/css/pane_tab_content.css
+++ b/css/pane_tab_content.css
@@ -73,6 +73,7 @@ body.styled-scrollbars .oblogger-content {
 .menu-item-icon.files-sort-confirmation { color: hsla(var(--accent-h) var(--accent-s) var(--accent-l)/90%); }
 
 .oblogger-content .title-container {
+    align-items: center;
     display: grid;
     grid-template-columns: min-content;
     height: 20px;
@@ -95,44 +96,26 @@ body.styled-scrollbars .oblogger-content {
 .oblogger-content .title-chevron {
     align-items: center;
     display: flex;
-    grid-column: 1;
-    height: 20px;
-}
-
-.oblogger-content .title-chevron .svg-icon.lucide-chevron-down {
-    color: var(--nav-indentation-guide-color);
-    height: 12px;
-    stroke-width: 4px;
-}
-
-.oblogger-content .pin .svg-icon.lucide-chevrons-down {
-    color: var(--nav-indentation-guide-color);
-    height: 16px;
-    stroke-width: 3px;
-}
-
-.oblogger-content .title-chevron.is-pinned .svg-icon.lucide-chevron-down {
-    display: none;
 }
 
 .oblogger-content .title-text {
     align-items: center;
     display: flex;
     font-size: 12px;
-    grid-column: 2;
+    grid-column: 1;
     overflow: hidden;
+    position: absolute;
 }
 
 .oblogger-content .text-icon {
-    align-items: center;
-    display: flex;
-    padding-right: 4px;
+
 }
 
 .oblogger-content .text-label {
     font-weight: 600;
     overflow: hidden;
     overflow-wrap: anywhere;
+    padding-left: 4px;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
@@ -388,6 +371,24 @@ body.styled-scrollbars .oblogger-content {
     width: 12px;
 }
 
+.oblogger-content .title-chevron .svg-icon.lucide-chevron-down {
+    color: transparent;
+    height: 16px;
+    width: 16px;
+    stroke-width: 2px;
+}
+
+.oblogger-content .pin .svg-icon.lucide-chevrons-down {
+    color: var(--nav-indentation-guide-color);
+    height: 16px;
+    width: 16px;
+    stroke-width: 2px;
+}
+
+.oblogger-content .title-chevron.is-pinned .svg-icon.lucide-chevron-down {
+    display: none;
+}
+
 .oblogger-content .title-tag .svg-icon {
     color: var(--nav-item-color);
     height: 11px;
@@ -455,6 +456,12 @@ body.styled-scrollbars .oblogger-content {
     transition: 0.2s;
     width: 85px;
 }
+
+.oblogger-content .title-container:hover .title-chevron .svg-icon {
+    color: hsla(var(--accent-h) var(--accent-s) var(--accent-l)/100%);
+}
+
+.oblogger-content .title-container:hover .text-icon .svg-icon { color: transparent; }
 
 .oblogger-content .text-label:hover { color: hsla(var(--accent-h) var(--accent-s) var(--accent-l)/100%); }
 

--- a/css/pane_tab_content.css
+++ b/css/pane_tab_content.css
@@ -395,9 +395,9 @@ body.styled-scrollbars .oblogger-content {
 }
 
 .oblogger-content .text-icon .svg-icon {
-    color: var(--nav-item-color);
-    height: 12px;
-    width: 12px;
+    color: hsla(var(--accent-h) var(--accent-s) var(--accent-l)/90%);
+    height: 16px;
+    width: 16px;
 }
 
 .oblogger-content .child-folder-icon .svg-icon {

--- a/css/pane_tab_content.css
+++ b/css/pane_tab_content.css
@@ -191,7 +191,7 @@ body.styled-scrollbars .oblogger-content {
 .oblogger-content .status-icon.visible {
     display: flex;
     grid-column: 1;
-    left: 19px;
+    left: 20px;
     opacity: 1;
     position: absolute;
 }

--- a/css/pane_tab_content.css
+++ b/css/pane_tab_content.css
@@ -425,7 +425,7 @@ body.styled-scrollbars .oblogger-content {
     width: 12px;
 }
 
-.oblogger-content .rx-child .collapsed .svg-icon:not(.content .svg-icon),
+.oblogger-content .rx-child .collapsed .svg-icon:not(.content .svg-icon, .oblogger-content .text-icon svg.svg-icon),
 .oblogger-content .title-container.collapsed .svg-icon:not(.oblogger-content .text-icon svg.svg-icon) { transform: rotate(-90deg); }
 
 

--- a/css/pane_tab_content.css
+++ b/css/pane_tab_content.css
@@ -96,6 +96,7 @@ body.styled-scrollbars .oblogger-content {
 .oblogger-content .title-chevron {
     align-items: center;
     display: flex;
+    padding-bottom: 1px;
 }
 
 .oblogger-content .title-text {

--- a/css/pane_tab_content.css
+++ b/css/pane_tab_content.css
@@ -126,7 +126,7 @@ body.styled-scrollbars .oblogger-content {
 .oblogger-content .text-icon {
     align-items: center;
     display: flex;
-    padding: 0 4px;
+    padding-right: 4px;
 }
 
 .oblogger-content .text-label {

--- a/css/pane_tab_content.css
+++ b/css/pane_tab_content.css
@@ -250,7 +250,7 @@ body.styled-scrollbars .oblogger-content {
 }
 
 .oblogger-content .content {
-    padding: 0 0 4px 12px;
+    padding: 0 0 4px 14px;
     transition-duration: 0.1s;
     transition-timing-function: cubic-bezier(0.02, 0.01, 0.47, 1);
 }

--- a/css/pane_tab_content.css
+++ b/css/pane_tab_content.css
@@ -16,14 +16,10 @@
 }
 
 /* modification for macos */
-.mod-macos .oblogger-content {
-    padding: 0 20px 70px 10px;
-}
+.mod-macos .oblogger-content { padding: 0 20px 70px 10px; }
 
 /* modification for minimal styled scrollbars setting */
-body.styled-scrollbars .oblogger-content {
-    padding: 0 4px 70px;
-}
+body.styled-scrollbars .oblogger-content { padding: 0 4px 70px; }
 
 .oblogger-content .hidden { display:none !important; }
 
@@ -79,19 +75,13 @@ body.styled-scrollbars .oblogger-content {
     height: 20px;
 }
 
-.oblogger-content .folder-holder.rx-child:last-child .content {
-    padding-bottom: 0;
-}
+.oblogger-content .folder-holder.rx-child:last-child .content { padding-bottom: 0; }
 
-.oblogger-content .folder-holder.rx-child:last-child .title-container.collapsed {
-    margin-bottom: 1px;
-}
+.oblogger-content .folder-holder.rx-child:last-child .title-container.collapsed { margin-bottom: 1px; }
 
 .oblogger-content .pin { display: none; }
 
-.oblogger-content .pin.is-pinned {
-    display: flex;
-}
+.oblogger-content .pin.is-pinned { display: flex; }
 
 .oblogger-content .title-chevron {
     align-items: center;
@@ -106,10 +96,6 @@ body.styled-scrollbars .oblogger-content {
     grid-column: 1;
     overflow: hidden;
     position: absolute;
-}
-
-.oblogger-content .text-icon {
-
 }
 
 .oblogger-content .text-label {
@@ -168,9 +154,7 @@ body.styled-scrollbars .oblogger-content {
     padding-left: 4px;
 }
 
-.oblogger-content .status-icon {
-    display: none;
-}
+.oblogger-content .status-icon { display: none; }
 
 .oblogger-content .status-icon.visible {
     display: flex;
@@ -386,9 +370,7 @@ body.styled-scrollbars .oblogger-content {
     stroke-width: 2px;
 }
 
-.oblogger-content .title-chevron.is-pinned .svg-icon.lucide-chevron-down {
-    display: none;
-}
+.oblogger-content .title-chevron.is-pinned .svg-icon.lucide-chevron-down { display: none; }
 
 .oblogger-content .title-tag .svg-icon {
     color: var(--nav-item-color);
@@ -458,17 +440,13 @@ body.styled-scrollbars .oblogger-content {
     width: 85px;
 }
 
-.oblogger-content .title-container:hover .title-chevron .svg-icon {
-    color: hsla(var(--accent-h) var(--accent-s) var(--accent-l)/100%);
-}
+.oblogger-content .title-container:hover .title-chevron .svg-icon { color: hsla(var(--accent-h) var(--accent-s) var(--accent-l)/100%); }
 
 .oblogger-content .title-container:hover .text-icon .svg-icon { color: transparent; }
 
 .oblogger-content .text-label:hover { color: hsla(var(--accent-h) var(--accent-s) var(--accent-l)/100%); }
 
-.oblogger-content .clickable-icon:hover {
-    background-color: transparent;
-}
+.oblogger-content .clickable-icon:hover { background-color: transparent; }
 
 .oblogger-content .family-title:hover {
     background-color: var(--nav-item-background-hover);
@@ -519,9 +497,7 @@ body.styled-scrollbars .oblogger-content {
     justify-items: center;
 }
 
-.is-phone .greeter.no-avatar {
-    display: flex;
-}
+.is-phone .greeter.no-avatar { display: flex; }
 
 .is-phone .greeter-title { grid-column: 1; }
 

--- a/src/containers/otc/otc_container.ts
+++ b/src/containers/otc/otc_container.ts
@@ -53,23 +53,6 @@ export abstract class OtcContainer extends ViewContainer {
             "up-arrow-with-tail"
     }
 
-    protected getPillClickHandler(): ((e: MouseEvent) => void) | undefined {
-        return (e: MouseEvent) => {
-            const menu = new Menu();
-
-            this.addSortOptionsToMenu(
-                menu,
-                [
-                    ContainerSortMethod.ALPHABETICAL,
-                    ContainerSortMethod.CTIME,
-                    ContainerSortMethod.MTIME
-                ]
-            );
-
-            menu.showAtMouseEvent(e);
-        }
-    }
-
     protected getContainerClass(): string {
         return "otc-child";
     }

--- a/src/containers/otc/property_container.ts
+++ b/src/containers/otc/property_container.ts
@@ -1,0 +1,47 @@
+import { ContainerCallbacks } from "../container_callbacks";
+import { ObloggerSettings, OtcGroupType } from "../../settings";
+import { App } from "obsidian";
+import { OtcContainer } from "./otc_container";
+import { FileState } from "../../constants";
+
+export class PropertyContainer extends OtcContainer {
+    constructor(
+        app: App,
+        settings: ObloggerSettings,
+        callbacks: ContainerCallbacks,
+        propertyName: string,
+        isPinned: boolean
+    ) {
+        super(
+            app,
+            settings,
+            callbacks,
+            OtcGroupType.PROPERTY_GROUP,
+            propertyName, // groupName
+            isPinned
+        );
+    }
+
+    protected buildFileStructure(excludedFolders: string[]): void {
+    }
+
+    protected getTextIcon(): string {
+        return "";
+    }
+
+    protected getTextIconTooltip(): string {
+        return "";
+    }
+
+    protected getTitleText(): string {
+        return this.groupName;
+    }
+
+    protected getTitleTooltip(): string {
+        return "";
+    }
+
+    protected wouldBeRendered(state: FileState): boolean {
+        return false;
+    }
+}

--- a/src/containers/otc/property_container.ts
+++ b/src/containers/otc/property_container.ts
@@ -38,6 +38,7 @@ export class PropertyContainer extends OtcContainer {
     private getAllValues(value: string, valueType: string): string[] {
         switch (valueType) {
             case "tags":
+            case "multitext":
                 if (Array.isArray(value)) {
                     return value.map(v => v.trim());
                 }

--- a/src/containers/otc/property_container.ts
+++ b/src/containers/otc/property_container.ts
@@ -45,7 +45,15 @@ export class PropertyContainer extends OtcContainer {
                 return value.split(",").map(v => v.trim());
             case "checkbox":
                 return [value ? "checked" : "unchecked"];
-            case "text":
+            case "datetime": {
+                const date = new Date(value);
+                const year = date.getFullYear();
+                const month = (date.getMonth() + 1).toString().padStart(2, '0');
+                const day = date.getDate().toString().padStart(2, '0');
+                const hour = date.getHours().toString().padStart(2, '0');
+                const minute = date.getMinutes().toString().padStart(2, '0');
+                return [`${year}-${month}-${day}, ${hour}:${minute}`];
+            } case "text":
             default:
                 return [(value.toString() ?? "").trim()];
         }

--- a/src/containers/otc/property_container.ts
+++ b/src/containers/otc/property_container.ts
@@ -80,22 +80,30 @@ export class PropertyContainer extends OtcContainer {
             return acc;
         }, {});
 
-        Object.entries(values).forEach((mapping) => {
-            const value = mapping[0];
-            const files = mapping[1];
-            if (files.length === 0) {
-                // nothing to do
-                return;
-            }
-            // add as a folder containing the files
-            files.forEach(fileWithFrontmatter => {
-                this.addFileToFolder(
-                    fileWithFrontmatter,
-                    value,
-                    "/"
-                )
+        const ascending = this.getGroupSettings()?.sortAscending ?? true;
+        const modifier = ascending ? 1 : -1;
+
+        Object.entries(values)
+            .sort(([valueA], [valueB]) => {
+                return modifier * (valueA < valueB ? -1 : valueA > valueB ? 1 : 0);
+            })
+            .forEach(([value, files]) => {
+                if (files.length === 0) {
+                    // nothing to do
+                    return;
+                }
+                // add as a folder containing the files
+                files
+                    .sort((fileA, fileB) => {
+                        return modifier * (fileA.name < fileB.name ? -1 : fileA.name > fileB.name ? 1 : 0);
+                    })
+                    .forEach(fileWithFrontmatter => {
+                        this.addFileToFolder(
+                            fileWithFrontmatter,
+                            value,
+                            "/");
+                    });
             });
-        });
     }
 
     protected getTextIcon(): string {

--- a/src/containers/otc/property_container.ts
+++ b/src/containers/otc/property_container.ts
@@ -1,6 +1,6 @@
 import { ContainerCallbacks } from "../container_callbacks";
-import { ObloggerSettings, OtcGroupType } from "../../settings";
-import { App, FrontMatterCache, TFile } from "obsidian";
+import { ContainerSortMethod, ObloggerSettings, OtcGroupType } from "../../settings";
+import { App, Menu, TFile } from "obsidian";
 import { OtcContainer } from "./otc_container";
 import { FileState } from "../../constants";
 
@@ -20,6 +20,19 @@ export class PropertyContainer extends OtcContainer {
             propertyName, // groupName
             isPinned
         );
+    }
+
+    protected getPillClickHandler(): ((e: MouseEvent) => void) | undefined {
+        return (e: MouseEvent) => {
+            const menu = new Menu();
+
+            this.addSortOptionsToMenu(
+                menu,
+                [ ContainerSortMethod.ALPHABETICAL ]
+            );
+
+            menu.showAtMouseEvent(e);
+        }
     }
 
     private getAllValues(value: string, valueType: string): string[] {
@@ -66,7 +79,7 @@ export class PropertyContainer extends OtcContainer {
             });
             return acc;
         }, {});
-        
+
         Object.entries(values).forEach((mapping) => {
             const value = mapping[0];
             const files = mapping[1];

--- a/src/containers/otc/property_container.ts
+++ b/src/containers/otc/property_container.ts
@@ -22,21 +22,20 @@ export class PropertyContainer extends OtcContainer {
         );
     }
 
-    private getCondensedValue(value: unknown, valueType: string): string {
+    private getAllValues(value: string, valueType: string): string[] {
         switch (valueType) {
             case "tags":
                 if (Array.isArray(value)) {
-                    return (value as Array<string>).map(tag => `#${tag}`).join(", ");
+                    return value.map(v => v.trim());
                 }
-                return `#${value as string}`;
+                return value.split(",").map(v => v.trim());
             case "text":
             default:
-                return (value as string) ?? "";
+                return [(value as string) ?? ""];
         }
     }
 
     protected buildFileStructure(excludedFolders: string[]): void {
-
         const filesWithFrontmatter = this.app.vault
             .getMarkdownFiles()
             .filter(file => {
@@ -52,29 +51,22 @@ export class PropertyContainer extends OtcContainer {
                 return !!fileWithValue.value;
             });
 
-        // // This function exists at run-time
-        // // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // // @ts-ignore
-        // const propertyType = this.app.metadataCache.getAllPropertyInfos()[this.groupName].type;
-        //
-        // const values = this.app.metadataCache
-        //     // This function exists at run-time
-        //     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        //     // @ts-ignore
-        //     .getFrontmatterPropertyValuesForKey(this.groupName)
-        //     .map((value: unknown) => this.getCondensedValue(value, propertyType));
+        // This function exists at run-time
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const propertyType = this.app.metadataCache.getAllPropertyInfos()[this.groupName].type;
 
         type ValueMap = {[key: string]: TFile[]};
         const values = filesWithFrontmatter.reduce((acc: ValueMap, cur) => {
-            if (!Object.keys(acc).contains(cur.value)) {
-                acc[cur.value.toString()] = [];
-            }
-            acc[cur.value.toString()].push(cur.file);
+            this.getAllValues(cur.value, propertyType).forEach((value) => {
+                if (!Object.keys(acc).contains(value)) {
+                    acc[value.toString()] = [];
+                }
+                acc[value.toString()].push(cur.file);
+            });
             return acc;
         }, {});
-
-
-        console.log(`values for ${this.groupName}: ${values}`)
+        
         Object.entries(values).forEach((mapping) => {
             const value = mapping[0];
             const files = mapping[1];

--- a/src/containers/otc/property_container.ts
+++ b/src/containers/otc/property_container.ts
@@ -44,7 +44,7 @@ export class PropertyContainer extends OtcContainer {
                 return value.split(",").map(v => v.trim());
             case "text":
             default:
-                return [(value as string) ?? ""];
+                return [((value as string) ?? "").trim()];
         }
     }
 
@@ -67,15 +67,15 @@ export class PropertyContainer extends OtcContainer {
         // This function exists at run-time
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        const propertyType = this.app.metadataCache.getAllPropertyInfos()[this.groupName].type;
+        const propertyType = this.app.metadataCache.getAllPropertyInfos()[this.groupName]?.type;
 
         type ValueMap = {[key: string]: TFile[]};
         const values = filesWithFrontmatter.reduce((acc: ValueMap, cur) => {
             this.getAllValues(cur.value, propertyType).forEach((value) => {
                 if (!Object.keys(acc).contains(value)) {
-                    acc[value.toString()] = [];
+                    acc[value.toString().trim()] = [];
                 }
-                acc[value.toString()].push(cur.file);
+                acc[value.toString().trim()].push(cur.file);
             });
             return acc;
         }, {});

--- a/src/containers/otc/property_container.ts
+++ b/src/containers/otc/property_container.ts
@@ -43,9 +43,11 @@ export class PropertyContainer extends OtcContainer {
                     return value.map(v => v.trim());
                 }
                 return value.split(",").map(v => v.trim());
-            case "text":
+            case "checkbox":
+                return [value ? "checked" : "unchecked"];
             default:
-                return [((value as string) ?? "").trim()];
+            case "text":
+                return [(value.toString() ?? "").trim()];
         }
     }
 

--- a/src/containers/otc/property_container.ts
+++ b/src/containers/otc/property_container.ts
@@ -45,8 +45,8 @@ export class PropertyContainer extends OtcContainer {
                 return value.split(",").map(v => v.trim());
             case "checkbox":
                 return [value ? "checked" : "unchecked"];
-            default:
             case "text":
+            default:
                 return [(value.toString() ?? "").trim()];
         }
     }

--- a/src/containers/otc/property_container.ts
+++ b/src/containers/otc/property_container.ts
@@ -54,7 +54,7 @@ export class PropertyContainer extends OtcContainer {
             const filesWithValue = filesWithFrontmatter
                 .filter(fileWithFrontmatter => {
                     const maybeValue = fileWithFrontmatter.frontmatter[this.groupName];
-                    return maybeValue?.toLowerCase() === value.toLowerCase();
+                    return maybeValue?.toString().toLowerCase() === value.toLowerCase();
                 });
             if (filesWithValue.length === 0) {
                 // nothing to do

--- a/src/containers/otc/property_container.ts
+++ b/src/containers/otc/property_container.ts
@@ -74,15 +74,11 @@ export class PropertyContainer extends OtcContainer {
             filesWithValue.forEach(fileWithFrontmatter => {
                 this.addFileToFolder(
                     fileWithFrontmatter.file,
-                    "",
-                    value
+                    value,
+                    "/"
                 )
             });
         });
-
-        // todo: use this call when creating the container
-        // this.app.metadataCache.getAllPropertyInfos()
-
     }
 
     protected getTextIcon(): string {

--- a/src/containers/otc/property_container.ts
+++ b/src/containers/otc/property_container.ts
@@ -55,13 +55,13 @@ export class PropertyContainer extends OtcContainer {
                 return !this.isFileExcluded(file, excludedFolders);
             }).map(file => {
                 const maybeFrontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
-                const value = maybeFrontmatter ? maybeFrontmatter[this.groupName] : undefined;
+                const value = maybeFrontmatter ? maybeFrontmatter[this.groupName] : null;
                 return {
                     file: file,
                     value: value
                 };
             }).filter(fileWithValue => {
-                return !!fileWithValue.value;
+                return fileWithValue.value !== null && fileWithValue.value !== undefined;
             });
 
         // This function exists at run-time

--- a/src/containers/otc/property_container.ts
+++ b/src/containers/otc/property_container.ts
@@ -1,6 +1,6 @@
 import { ContainerCallbacks } from "../container_callbacks";
 import { ObloggerSettings, OtcGroupType } from "../../settings";
-import { App } from "obsidian";
+import { App, FrontMatterCache, TFile } from "obsidian";
 import { OtcContainer } from "./otc_container";
 import { FileState } from "../../constants";
 
@@ -23,6 +23,66 @@ export class PropertyContainer extends OtcContainer {
     }
 
     protected buildFileStructure(excludedFolders: string[]): void {
+        // This function exists at run-time
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const values = this.app.metadataCache.getFrontmatterPropertyValuesForKey(this.groupName)
+
+        // We explicitly filter out undefined frontmatter as a final step,
+        // but the linter and ts don't understand that. Maybe there's a
+        // cleaner way to do this that doesn't involve disabling the
+        // linter?
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const filesWithFrontmatter: {
+            frontmatter: FrontMatterCache;
+            file: TFile
+        }[] = this.app.vault
+            .getMarkdownFiles()
+            .filter(file => {
+                return !this.isFileExcluded(file, excludedFolders);
+            }).map(file => {
+                return {
+                    file: file,
+                    frontmatter: this.app.metadataCache.getFileCache(file)?.frontmatter
+                };
+            }).filter(fileWithMetadata => {
+                return !!(fileWithMetadata.frontmatter);
+            });
+
+        values.forEach((value: string) => {
+            const filesWithValue = filesWithFrontmatter
+                .filter(fileWithFrontmatter => {
+                    const maybeValue = fileWithFrontmatter.frontmatter[this.groupName];
+                    return maybeValue?.toLowerCase() === value.toLowerCase();
+                });
+            if (filesWithValue.length === 0) {
+                // nothing to do
+                return;
+            }
+            if (filesWithValue.length === 1) {
+                // add as a file
+                const fileWithFrontmatter = filesWithValue.first();
+                fileWithFrontmatter && this.addFileToFolder(
+                    fileWithFrontmatter.file,
+                    "",
+                    "/"
+                )
+                return;
+            }
+            // add as a folder containing the files
+            filesWithValue.forEach(fileWithFrontmatter => {
+                this.addFileToFolder(
+                    fileWithFrontmatter.file,
+                    "",
+                    value
+                )
+            });
+        });
+
+        // todo: use this call when creating the container
+        // this.app.metadataCache.getAllPropertyInfos()
+
     }
 
     protected getTextIcon(): string {
@@ -42,6 +102,10 @@ export class PropertyContainer extends OtcContainer {
     }
 
     protected wouldBeRendered(state: FileState): boolean {
-        return false;
+        // if we don't have frontmatter, then it's not going to be rendered
+        if (!state.maybeMetadata?.frontmatter) {
+            return false;
+        }
+        return Object.keys(state.maybeMetadata?.frontmatter).contains(this.groupName);
     }
 }

--- a/src/containers/otc/property_container.ts
+++ b/src/containers/otc/property_container.ts
@@ -93,6 +93,8 @@ export class PropertyContainer extends OtcContainer {
 
         const ascending = this.getGroupSettings()?.sortAscending ?? true;
         const modifier = ascending ? 1 : -1;
+        const sortMethod = this.getGroupSettings()?.sortMethod ?? ContainerSortMethod.ALPHABETICAL;
+        const fileSortingFn = this.getFileSortingFn(sortMethod);
 
         Object.entries(values)
             .sort(([valueA], [valueB]) => {
@@ -106,7 +108,11 @@ export class PropertyContainer extends OtcContainer {
                 // add as a folder containing the files
                 files
                     .sort((fileA, fileB) => {
-                        return modifier * (fileA.name < fileB.name ? -1 : fileA.name > fileB.name ? 1 : 0);
+                        const bookmarkSorting = this.sortFilesByBookmark(fileA, fileB);
+                        if (bookmarkSorting != 0) {
+                            return bookmarkSorting;
+                        }
+                        return (ascending ? 1 : -1) * fileSortingFn(fileA, fileB);
                     })
                     .forEach(fileWithFrontmatter => {
                         this.addFileToFolder(

--- a/src/containers/otc/property_container.ts
+++ b/src/containers/otc/property_container.ts
@@ -107,7 +107,7 @@ export class PropertyContainer extends OtcContainer {
     }
 
     protected getTextIcon(): string {
-        return "";
+        return "text";
     }
 
     protected getTextIconTooltip(): string {

--- a/src/containers/otc/tag_group_container.ts
+++ b/src/containers/otc/tag_group_container.ts
@@ -1,4 +1,4 @@
-import { App, getAllTags, TFile } from "obsidian";
+import { App, getAllTags, Menu, TFile } from "obsidian";
 import { ContainerSortMethod, ObloggerSettings, OtcGroupType } from "../../settings";
 import { FileState } from "../../constants";
 import { ContainerCallbacks } from "../container_callbacks";
@@ -139,6 +139,23 @@ export class TagGroupContainer extends OtcContainer {
                 });
                 return acc;
             }, {});
+    }
+
+    protected getPillClickHandler(): ((e: MouseEvent) => void) | undefined {
+        return (e: MouseEvent) => {
+            const menu = new Menu();
+
+            this.addSortOptionsToMenu(
+                menu,
+                [
+                    ContainerSortMethod.ALPHABETICAL,
+                    ContainerSortMethod.CTIME,
+                    ContainerSortMethod.MTIME
+                ]
+            );
+
+            menu.showAtMouseEvent(e);
+        }
     }
 
     protected buildFileStructure(excludedFolders: string[]) {

--- a/src/containers/otc/tag_group_container.ts
+++ b/src/containers/otc/tag_group_container.ts
@@ -70,7 +70,7 @@ export class TagGroupContainer extends OtcContainer {
         if (this.getIsolatedTagMatch()) {
             return "tags";
         }
-        return "";
+        return "hash";
     }
 
     protected getTextIconTooltip(): string {

--- a/src/containers/rx/dailies_container.ts
+++ b/src/containers/rx/dailies_container.ts
@@ -48,6 +48,10 @@ export class DailiesContainer extends RxContainer {
         return `No documents tagged #${this.settings.dailiesTag};`
     }
 
+    protected getTextIcon(): string {
+        return "calendar-days";
+    }
+
     protected getTitleText(): string {
         return "Daily Notes";
     }

--- a/src/containers/rx/files_container.ts
+++ b/src/containers/rx/files_container.ts
@@ -48,6 +48,10 @@ export class FilesContainer extends RxContainer {
             "up-arrow-with-tail"
     }
 
+    protected getTextIcon(): string {
+        return "package-2";
+    }
+
     protected getTitleText(): string {
         return "Files";
     }

--- a/src/containers/rx/recents_container.ts
+++ b/src/containers/rx/recents_container.ts
@@ -42,6 +42,10 @@ export class RecentsContainer extends RxContainer {
         return "No recents";
     }
 
+    protected getTextIcon(): string {
+        return "history";
+    }
+
     protected getTitleText(): string {
         return "Recents";
     }

--- a/src/containers/rx/rx_container.ts
+++ b/src/containers/rx/rx_container.ts
@@ -38,10 +38,6 @@ export abstract class RxContainer extends ViewContainer {
         return "";
     }
 
-    protected getTextIcon(): string {
-        return "";
-    }
-
     protected getTextIconTooltip(): string {
         return "";
     }

--- a/src/containers/rx/untagged_container.ts
+++ b/src/containers/rx/untagged_container.ts
@@ -43,6 +43,10 @@ export class UntaggedContainer extends RxContainer {
         return "No untagged documents";
     }
 
+    protected getTextIcon(): string {
+        return "alert-circle";
+    }
+
     protected getTitleText(): string {
         return "Untagged";
     }

--- a/src/containers/view_container.ts
+++ b/src/containers/view_container.ts
@@ -417,8 +417,9 @@ export abstract class ViewContainer extends GroupFolder {
 
         const titleText = document.createElement("div");
         titleText.addClass("title-text");
-        titleText.appendChild(textLabel);
         titleText.appendChild(textIcon);
+        titleText.appendChild(textLabel);
+
 
         titleText.addEventListener("click", () => {
             this.toggleCollapse();

--- a/src/new_property_modal.ts
+++ b/src/new_property_modal.ts
@@ -1,7 +1,7 @@
 import { App, FuzzySuggestModal, Notice } from "obsidian";
 
 
-export class NewTagModal extends FuzzySuggestModal<string> {
+export class NewPropertyModal extends FuzzySuggestModal<string> {
     onSelect: (tag: string) => void
 
     constructor(app: App, onSelect: (tag: string) => Promise<void>) {
@@ -9,22 +9,10 @@ export class NewTagModal extends FuzzySuggestModal<string> {
         this.onSelect = onSelect;
     }
     getItems(): string[] {
+        // The `getAllPropertyInfos()` function is added at runtime
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        const allTags = Object.keys(this.app.metadataCache.getTags());
-        const individualTags = new Set<string>();
-        allTags.forEach(fullTag => {
-            fullTag.split("/").forEach(splitTag => {
-                if (allTags.contains(splitTag)) {
-                    return;
-                }
-                if (splitTag.startsWith("#")) {
-                    splitTag = splitTag.substring(1);
-                }
-                individualTags.add(`.../${splitTag}/...`);
-            });
-        });
-        return allTags.concat(Array.from(individualTags));
+        return Object.keys(this.app.metadataCache.getAllPropertyInfos());
     }
 
     getItemText(tag: string): string {
@@ -35,7 +23,6 @@ export class NewTagModal extends FuzzySuggestModal<string> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     onChooseItem(value: string, evt: MouseEvent | KeyboardEvent) {
         new Notice(`Selected ${value}`);
-        const tag = value.startsWith("#") ? value.substring(1) : value;
-        this.onSelect(tag);
+        this.onSelect(value);
     }
 }

--- a/src/new_property_modal.ts
+++ b/src/new_property_modal.ts
@@ -12,7 +12,7 @@ export class NewPropertyModal extends FuzzySuggestModal<string> {
         // The `getAllPropertyInfos()` function is added at runtime
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
-        return Object.keys(this.app.metadataCache.getAllPropertyInfos());
+        return Object.keys(this.app.metadataCache.getAllPropertyInfos()).sort();
     }
 
     getItemText(tag: string): string {

--- a/src/new_property_modal.ts
+++ b/src/new_property_modal.ts
@@ -1,0 +1,41 @@
+import { App, FuzzySuggestModal, Notice } from "obsidian";
+
+
+export class NewTagModal extends FuzzySuggestModal<string> {
+    onSelect: (tag: string) => void
+
+    constructor(app: App, onSelect: (tag: string) => Promise<void>) {
+        super(app);
+        this.onSelect = onSelect;
+    }
+    getItems(): string[] {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const allTags = Object.keys(this.app.metadataCache.getTags());
+        const individualTags = new Set<string>();
+        allTags.forEach(fullTag => {
+            fullTag.split("/").forEach(splitTag => {
+                if (allTags.contains(splitTag)) {
+                    return;
+                }
+                if (splitTag.startsWith("#")) {
+                    splitTag = splitTag.substring(1);
+                }
+                individualTags.add(`.../${splitTag}/...`);
+            });
+        });
+        return allTags.concat(Array.from(individualTags));
+    }
+
+    getItemText(tag: string): string {
+        return tag;
+    }
+
+    // evt isn't used, but we need it to handle the onChooseItem
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onChooseItem(value: string, evt: MouseEvent | KeyboardEvent) {
+        new Notice(`Selected ${value}`);
+        const tag = value.startsWith("#") ? value.substring(1) : value;
+        this.onSelect(tag);
+    }
+}

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -628,32 +628,32 @@ export class ObloggerView extends ItemView {
             });
     }
 
-    private removePropertyGroup(propertyName: string) { }
-
     private movePropertyGroup(propertyName: string, up: boolean) { }
 
-    private async removeTagGroup(tag: string) {
-        const tagGroups = this.otcContainers.filter(container => {
+    private async removeOtcGroup(groupType: OtcGroupType, groupName: string) {
+        const containers = this.otcContainers.filter(container => {
             return (
-                container.groupType === OtcGroupType.TAG_GROUP &&
-                container.groupName === tag);
+                container.groupType === groupType &&
+                container.groupName === groupName);
         });
-        const tagGroup = tagGroups.first();
-        if (tagGroup === undefined) {
-            new Notice("Nothing to delete");
+        const container = containers.first();
+        if (container === undefined) {
+            new Notice(`Unable to find group of type ${groupType} with name ${groupName}`);
             return;
         }
-        if (tagGroup.groupName !== tag) {
-            console.debug("Something went wrong, tag group has wrong tag.");
+        if (container.groupName !== groupName) {
+            console.debug("Something went wrong, container has the wrong name.");
             return;
         }
-        this.otcContainers.remove(tagGroup);
-        tagGroup.rootElement.remove();
+        this.otcContainers.remove(container);
+        container.rootElement.remove();
         this.settings.otcGroups = this.settings?.otcGroups
-            .filter(group => group.groupName !== tag);
+            .filter(group => {
+                return group.groupName !== groupName || group.groupType != groupType
+            });
         await this.saveSettingsCallback();
         this.requestRender();
-        new Notice(`"${tag}" removed`);
+        new Notice(`"${groupName}" removed`);
     }
 
     private async moveRxGroup(groupType: RxGroupType, up: boolean) {
@@ -744,7 +744,7 @@ export class ObloggerView extends ItemView {
             requestRenderCallback: () => { this.requestRender() },
             saveSettingsCallback: this.saveSettingsCallback,
             getGroupIconCallback: (isCollapsed) => isCollapsed ? "folder-closed" : "folder-open",
-            hideCallback: async () => { return await this.removeTagGroup(groupName); },
+            hideCallback: async () => { return await this.removeOtcGroup(OtcGroupType.TAG_GROUP, groupName); },
             moveCallback: (up: boolean) => { return this.moveTagGroup(groupName, up); },
             pinCallback: (pin: boolean) => { return this.pinOtcGroup(OtcGroupType.TAG_GROUP, groupName, pin); }
         };
@@ -773,7 +773,7 @@ export class ObloggerView extends ItemView {
             requestRenderCallback: () => { this.requestRender() },
             saveSettingsCallback: this.saveSettingsCallback,
             getGroupIconCallback: (isCollapsed) => isCollapsed ? "folder-closed" : "folder-open",
-            hideCallback: async () => { return await this.removePropertyGroup(groupName); },
+            hideCallback: async () => { return await this.removeOtcGroup(OtcGroupType.PROPERTY_GROUP, groupName); },
             moveCallback: (up: boolean) => { return this.movePropertyGroup(groupName, up); },
             pinCallback: (pin: boolean) => { return this.pinOtcGroup(OtcGroupType.PROPERTY_GROUP, groupName, pin); }
         };

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -691,19 +691,23 @@ export class ObloggerView extends ItemView {
         this.requestRender();
     }
 
-    private movePropertyGroup(propertyName: string, up: boolean) { }
-
-    private async moveTagGroup(tag: string, up: boolean): Promise<void> {
+    private async moveOtcGroup(
+        groupType: OtcGroupType,
+        groupName: string,
+        up: boolean
+    ): Promise<void> {
         const otcGroups = this.settings.otcGroups;
-        const currentIndex = otcGroups.findIndex(group => group.groupName === tag);
+        const currentIndex = otcGroups.findIndex((group) => {
+            return group.groupType === groupType && group.groupName === groupName;
+        });
         if (currentIndex === -1) {
-            console.warn(`Tag ${tag} doesn't exist.`);
+            console.warn(`Group of type ${groupType} with name ${groupName} couldn't be found.`);
             return;
         }
 
         // find the next group of the same type
         let newIndex = currentIndex + (up ? -1 : 1);
-        while (newIndex > 0 && otcGroups.at(newIndex)?.groupType !== OtcGroupType.TAG_GROUP) {
+        while (newIndex > 0 && otcGroups.at(newIndex)?.groupType !== groupType) {
             newIndex += (up ? -1 : 1);
         }
 
@@ -750,7 +754,7 @@ export class ObloggerView extends ItemView {
             saveSettingsCallback: this.saveSettingsCallback,
             getGroupIconCallback: (isCollapsed) => isCollapsed ? "folder-closed" : "folder-open",
             hideCallback: async () => { return await this.removeOtcGroup(OtcGroupType.TAG_GROUP, groupName); },
-            moveCallback: (up: boolean) => { return this.moveTagGroup(groupName, up); },
+            moveCallback: (up: boolean) => { return this.moveOtcGroup(OtcGroupType.TAG_GROUP, groupName, up); },
             pinCallback: (pin: boolean) => { return this.pinOtcGroup(OtcGroupType.TAG_GROUP, groupName, pin); }
         };
 
@@ -779,7 +783,7 @@ export class ObloggerView extends ItemView {
             saveSettingsCallback: this.saveSettingsCallback,
             getGroupIconCallback: (isCollapsed) => isCollapsed ? "folder-closed" : "folder-open",
             hideCallback: async () => { return await this.removeOtcGroup(OtcGroupType.PROPERTY_GROUP, groupName); },
-            moveCallback: (up: boolean) => { return this.movePropertyGroup(groupName, up); },
+            moveCallback: (up: boolean) => { return this.moveOtcGroup(OtcGroupType.PROPERTY_GROUP, groupName, up); },
             pinCallback: (pin: boolean) => { return this.pinOtcGroup(OtcGroupType.PROPERTY_GROUP, groupName, pin); }
         };
 

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -628,8 +628,6 @@ export class ObloggerView extends ItemView {
             });
     }
 
-    private movePropertyGroup(propertyName: string, up: boolean) { }
-
     private async removeOtcGroup(groupType: OtcGroupType, groupName: string) {
         const containers = this.otcContainers.filter(container => {
             return (
@@ -693,24 +691,31 @@ export class ObloggerView extends ItemView {
         this.requestRender();
     }
 
+    private movePropertyGroup(propertyName: string, up: boolean) { }
+
     private async moveTagGroup(tag: string, up: boolean): Promise<void> {
-        const currentIndex = this.settings.otcGroups.findIndex(group => group.groupName === tag);
+        const otcGroups = this.settings.otcGroups;
+        const currentIndex = otcGroups.findIndex(group => group.groupName === tag);
         if (currentIndex === -1) {
             console.warn(`Tag ${tag} doesn't exist.`);
             return;
         }
 
-        const newIndex = currentIndex + (up ? -1 : 1);
+        // find the next group of the same type
+        let newIndex = currentIndex + (up ? -1 : 1);
+        while (newIndex > 0 && otcGroups.at(newIndex)?.groupType !== OtcGroupType.TAG_GROUP) {
+            newIndex += (up ? -1 : 1);
+        }
 
-        if (newIndex < 0 || newIndex >= this.settings.otcGroups.length) {
+        if (newIndex < 0 || newIndex >= otcGroups.length) {
             console.log(`Already at ${up ? "top" : "bottom"}`);
             return;
         }
 
         // todo(#215): try to get this to one operation using splice to swap in place
-        const group = this.settings.otcGroups[currentIndex];
-        this.settings.otcGroups.remove(group);
-        this.settings.otcGroups.splice(newIndex, 0, group);
+        const group = otcGroups[currentIndex];
+        otcGroups.remove(group);
+        otcGroups.splice(newIndex, 0, group);
 
         await this.saveSettingsCallback();
         this.reloadOtcGroups();

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -32,6 +32,7 @@ import { NewTagModal } from "./new_tag_modal";
 import { buildStateFromFile, FileState } from "./constants";
 import { ContainerCallbacks } from "./containers/container_callbacks";
 import { PropertyContainer } from "./containers/otc/property_container";
+import { NewPropertyModal } from "./new_property_modal";
 
 export const VIEW_TYPE_OBLOGGER = "oblogger-view";
 const RENDER_DELAY_MS = 100;
@@ -448,6 +449,30 @@ export class ObloggerView extends ItemView {
         return this.greeterDiv;
     }
 
+    private showNewPropertyModal() {
+        const modal = new NewPropertyModal(this.app, async (result: string) => {
+            if (!this.settings.otcGroups) {
+                this.settings.otcGroups = [];
+            }
+            // add the group to settings and then reload
+            this.settings.otcGroups.push({
+                groupName: result,
+                groupType: OtcGroupType.PROPERTY_GROUP,
+                collapsedFolders: [],
+                isVisible: true,
+                isPinned: false,
+                sortMethod: ContainerSortMethod.ALPHABETICAL,
+                sortAscending: true,
+                excludedFolders: [],
+                logsFolderVisible: false,
+                templatesFolderVisible: false
+            });
+            await this.saveSettingsCallback();
+            this.reloadOtcGroups();
+        });
+        modal.open();
+    }
+
     private showNewTagModal() {
         const modal = new NewTagModal(this.app, async (result: string)=> {
             if (!this.settings.otcGroups) {
@@ -496,6 +521,11 @@ export class ObloggerView extends ItemView {
             .setIcon("folder-plus")
             .setTooltip("Add a new user tag group")
             .onClick(() => this.showNewTagModal());
+
+        new ButtonComponent(buttonBarDiv)
+            .setClass("button-bar-button")
+            .setIcon("dog")
+            .onClick(() => this.showNewPropertyModal());
 
         new ButtonComponent(buttonBarDiv)
             .setClass("button-bar-button")

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -518,14 +518,25 @@ export class ObloggerView extends ItemView {
 
         new ButtonComponent(buttonBarDiv)
             .setClass("button-bar-button")
-            .setIcon("folder-plus")
-            .setTooltip("Add a new user tag group")
-            .onClick(() => this.showNewTagModal());
+            .setIcon("plus-square")
+            .setTooltip("Add new user group")
+            .onClick((e) => {
+                const menu = new Menu();
 
-        new ButtonComponent(buttonBarDiv)
-            .setClass("button-bar-button")
-            .setIcon("dog")
-            .onClick(() => this.showNewPropertyModal());
+                menu.addItem(item => {
+                    item.setIcon("hash");
+                    item.setTitle("Add tag group");
+                    item.onClick(() => this.showNewTagModal())
+
+                    menu.addItem(item => {
+                        item.setIcon("text");
+                        item.setTitle("Add property group");
+                        item.onClick(() => this.showNewPropertyModal())
+                    })
+                })
+                menu.showAtMouseEvent(e);
+            })
+
 
         new ButtonComponent(buttonBarDiv)
             .setClass("button-bar-button")

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -21,7 +21,7 @@ import {
 } from "./settings";
 import { TagGroupContainer } from "./containers/otc/tag_group_container";
 import { DailiesContainer } from "./containers/rx/dailies_container";
-import { FileClickCallback, GroupFolder } from "./containers/group_folder";
+import { FileClickCallback } from "./containers/group_folder";
 import { RecentsContainer } from "./containers/rx/recents_container";
 import { UntaggedContainer } from "./containers/rx/untagged_container";
 import { FilesContainer } from "./containers/rx/files_container";

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -464,7 +464,7 @@ export class ObloggerView extends ItemView {
                 sortMethod: ContainerSortMethod.ALPHABETICAL,
                 sortAscending: true,
                 excludedFolders: [],
-                logsFolderVisible: false,
+                logsFolderVisible: true,
                 templatesFolderVisible: false
             });
             await this.saveSettingsCallback();

--- a/src/oblogger_view.ts
+++ b/src/oblogger_view.ts
@@ -847,6 +847,7 @@ export class ObloggerView extends ItemView {
         // Dump whatever remains (hopefully not much)
         this.otcGroupsDiv?.empty();
 
+        // todo: need to add a separator somewhere in here?
         Object.values(OtcGroupType).forEach(groupType => {
             const groups = this.settings?.otcGroups
                 .filter(group => group.groupType === groupType)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -46,7 +46,8 @@ export const isValidRxGroupType = (groupType: RxGroupType): boolean => {
 
 // Note: when adding new types, ensure that the value = NAME.toLowerCase()
 export enum OtcGroupType {
-    TAG_GROUP = "tag_group"
+    TAG_GROUP = "tag_group",
+    PROPERTY_GROUP = "property_group"
 }
 
 export const isValidOtcGroupType = (groupType: OtcGroupType): boolean => {

--- a/test-vault/2023-09-12.md
+++ b/test-vault/2023-09-12.md
@@ -1,5 +1,7 @@
 ---
-tag: entry
+tags:
+  - entry
+  - gardening
 day: 2023-09-12
 ---
 


### PR DESCRIPTION
fixes #112 

- adds group icons and adjusts padding
- hides collapse icons when not hovering
- create new `OtcContainer` called `PropertyContainer` which shows property values for a selected property field
- differentiate sort options for `PropertyContainer`s and `TagGroupContainer`s
- Adds a new modal similar to the tag selector modal that selects a property field
- removes specific rendering of rx containers for a generic call using group type
- Adds menu to add tag group button to add either tag group or property group
- Change variable names to match the generic otc group vs specifically tag group