### PR TITLE
fix mobile issue

### DIFF
--- a/src/logger_modal.ts
+++ b/src/logger_modal.ts
@@ -194,6 +194,7 @@ export class LoggerModal extends Modal {
         typeInputDiv.addClass("field-div");
         this.typeInput = new TextComponent(typeInputDiv);
         this.typeInput.setPlaceholder("type");
+        const typeValues = Array.from(this.logMap.keys()).filter(t => t !== "");
         const typeSuggest = new StringPopoverSuggest(
             this.app,
             this.typeInput.inputEl,
@@ -202,7 +203,7 @@ export class LoggerModal extends Modal {
                 this.typeInput?.onChanged();
                 this.rebuildFieldsDiv();
             },
-            Array.from(this.logMap.keys()).filter(t => t !== ""));
+            typeValues);
         this.typeInput.onChange((value) => {
             typeSuggest.suggestFrom(value);
             this.logFrontmatter.type = value;

--- a/src/string_popover_suggest.ts
+++ b/src/string_popover_suggest.ts
@@ -1,5 +1,4 @@
 import { App, PopoverSuggest, prepareFuzzySearch } from "obsidian";
-import { isDesktopLikeResolution } from "./constants";
 
 const CLOSE_OPTION = "CLOSE_OPTION";
 
@@ -88,17 +87,12 @@ export class StringPopoverSuggest extends PopoverSuggest<string> {
         }
         this.suggestions.setSuggestions([CLOSE_OPTION].concat(suggestions));
 
-        // Using a minimum resolution width to determine desktop (including ipad)
-        // and mobile, in order to move the suggester window to the correct
-        // position.
-        if (isDesktopLikeResolution()) {
-            const rect = this.parentEl.getBoundingClientRect();
-            this.suggestEl.style.width = rect.width + 'px'
+        const rect = this.parentEl.getBoundingClientRect();
+        this.suggestEl.style.width = rect.width + 'px'
 
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            this.reposition(rect);
-        }
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        this.reposition(rect);
 
         this.open();
     }


### PR DESCRIPTION
popup suggesters weren't showing up in mobile. this pr removes the "desktop only" condition from repositioning the popup.

not sure why this changed. my guess is that there was an obsidian update recently that changed this behavior.