### PR TITLE
fix logging modal flicker

### DIFF
--- a/src/logger_modal.ts
+++ b/src/logger_modal.ts
@@ -30,9 +30,9 @@ const EXCLUDED_FIELDS = new Set([
 
 export class LoggerModal extends Modal {
     settings: ObloggerSettings;
-    logMap: Map<string, TFile[]>
-    typeInput: TextComponent | undefined
-    fieldsDiv: HTMLElement | undefined
+    logMap: Map<string, TFile[]>;
+    typeInput: TextComponent | undefined;
+    fieldsDiv: HTMLElement | undefined;
     logFrontmatter: {[id: string]: string};
     logContent: string;
     submitButton: HTMLElement | undefined;

--- a/src/logger_modal.ts
+++ b/src/logger_modal.ts
@@ -209,7 +209,7 @@ export class LoggerModal extends Modal {
             this.logFrontmatter.type = value;
         });
         this.typeInput.inputEl.addEventListener("focusout", () => {
-            setTimeout(() => { this.rebuildFieldsDiv(); }, 100);
+            this.rebuildFieldsDiv();
         });
         typeDiv.appendChild(typeInputDiv);
 

--- a/src/logger_modal.ts
+++ b/src/logger_modal.ts
@@ -206,7 +206,9 @@ export class LoggerModal extends Modal {
             },
             types);
         this.typeInput.inputEl.addEventListener("focusout", () => {
-            this.rebuildFieldsDiv();
+            if (this.typeInput?.getValue() !== this.logFrontmatter.type) {
+                this.rebuildFieldsDiv();
+            }
         });
         typeDiv.appendChild(typeInputDiv);
 

--- a/src/logger_modal.ts
+++ b/src/logger_modal.ts
@@ -205,9 +205,6 @@ export class LoggerModal extends Modal {
                 typeSuggester.close();
             },
             types);
-        this.typeInput.onChange((value) => {
-            this.logFrontmatter.type = value;
-        });
         this.typeInput.inputEl.addEventListener("focusout", () => {
             this.rebuildFieldsDiv();
         });

--- a/src/logger_modal.ts
+++ b/src/logger_modal.ts
@@ -286,6 +286,8 @@ export class LoggerModal extends Modal {
         }
 
         const currentType = this.typeInput?.getValue() ?? "";
+        this.logFrontmatter.type = currentType;
+
         const files = this.logMap.get(currentType) ?? [];
 
         const fieldsMap = files.reduce((acc, file) => {


### PR DESCRIPTION
this fixes a graphical glitch in the logger modal.

What was happening was you would enter in a type, it would fill in all the fields, then you would go back to the type field and and then click on one of the existing fields to confirm your typing.

the clicking on a field would first pop up the field's suggester, then it would get the focusout signal which rebuilds the fields based on the type, which closes the field's suggester.

the extra 100ms delay that was in here before made this behavior really apparent. the suggester for the field would pop up, then go away.

with this change, we...
- remove the delay (not sure why it was added in the first place and seems unnecessary)
- only rebuilds the modal if the type actually changes